### PR TITLE
Fix problem identifyin' mismatch'd errors in plurals

### DIFF
--- a/dennis/cmdline.py
+++ b/dennis/cmdline.py
@@ -160,32 +160,31 @@ def lint_cmd(scriptname, command, argv):
 
         error_count = 0
         warning_count = 0
+
         for entry in problem_results:
-            # TODO: This is totally shite code.
-            for code, trstr, msg in entry.errors:
-                total_error_count += 1
-                error_count += 1
-                if not options.quiet:
+            total_error_count = total_error_count + len(entry.errors)
+            error_count = error_count + len(entry.errors)
+
+            if not options.quiet:
+                # TODO: This is totally shite code.
+                for code, trstr, msg in entry.errors:
                     print_utf8(TERMINAL.bold_red(u'Error: {0}: {1}'.format(
                                 code, msg)))
-                    if trstr.msgid_field != 'msgid':
-                        print_utf8(u'msgid: "{0}"'.format(entry.msgid))
-                    print_utf8(u'{0} "{1}"'.format(
-                            trstr.msgid_field, trstr.msgid_string))
+                    for field, s in zip(trstr.msgid_fields, trstr.msgid_strings):
+                        print_utf8(u'{0} "{1}"'.format(field, s))
                     print_utf8(u'{0} "{1}"'.format(
                             trstr.msgstr_field, trstr.msgstr_string))
                     print ''
 
-            for code, trstr, msg in entry.warnings:
-                total_warning_count += 1
-                warning_count += 1
-                if not options.quiet and not options.errorsonly:
+            total_warning_count = total_warning_count + len(entry.warnings)
+            warning_count = warning_count + len(entry.warnings)
+
+            if not options.quiet and not options.errorsonly:
+                for code, trstr, msg in entry.warnings:
                     print_utf8(TERMINAL.bold_yellow(u'Warning: {0}: {1}'.format(
                                 code, msg)))
-                    if trstr.msgid_field != 'msgid':
-                        print_utf8(u'msgid: "{0}"'.format(entry.msgid))
-                    print_utf8(u'{0} "{1}"'.format(
-                            trstr.msgid_field, trstr.msgid_string))
+                    for field, s in zip(trstr.msgid_fields, trstr.msgid_strings):
+                        print_utf8(u'{0} "{1}"'.format(field, s))
                     print_utf8(u'{0} "{1}"'.format(
                             trstr.msgstr_field, trstr.msgstr_string))
                     print ''

--- a/dennis/tests/test_linter.py
+++ b/dennis/tests/test_linter.py
@@ -163,6 +163,22 @@ class MismatchedVarsLintRuleTests(LintRuleTestCase):
         eq_(linted_entry.errors[0][2],
             'invalid variables: {foo}')
 
+    def test_plurals(self):
+        # It's possible for the msgid to have no variables in it and
+        # the msgid_plural to have variables in it. msgstr[n] strings
+        # should be compared against the set of variables in msgid and
+        # msgid_plural. This tests the common case.
+        linted_entry = build_linted_entry(
+            '#: foo/foo.py:5\n'
+            'msgid "1 reply"\n'
+            'msgid_plural "{n} replies"\n'
+            'msgstr[0] "{n} mooo"\n')
+
+        self.mvlr.lint(self.vartok, linted_entry)
+
+        eq_(len(linted_entry.warnings), 0)
+        eq_(len(linted_entry.errors), 0)
+
 
 class MalformedVarsLintRuleTests(LintRuleTestCase):
     mavlr = MalformedVarsLintRule()


### PR DESCRIPTION
It's possible fer th' msgid to have nay variables in it and th'
msgid_plural to have variables in it. msgstrr[n] strings should be
compar'd against th' set o' variables in msgid and msgid_plural.

Forr example:

```
#. {n} is th' numberr o' replies.
msgid "1 reply"
msgid_plural "{n} replies"
msgstrr[0] "{n} pirates in a dingy"
```

Priorr to this commit, this would raise an errorr, but that's not correct.
This fixes that.

Fixes #25.
