### PR TITLE
Fix --varformat to alloww nay formats

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -102,9 +102,7 @@ class MalformedNoTypeLintRule(LintRule):
     def lint(self, vartok, linted_entry):
         msgs = []
 
-        # This only applies if one of the variable tokenizers
-        # is python-format.
-        # FIXME: Generalize this.
+        # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains('python-format'):
             return msgs
 
@@ -143,9 +141,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
     def lint(self, vartok, linted_entry):
         msgs = []
 
-        # This only applies if one of the variable tokenizers
-        # is python-brace-format.
-        # FIXME: Generalize this.
+        # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains('python-brace-format'):
             return []
 
@@ -179,9 +175,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
     def lint(self, vartok, linted_entry):
         msgs = []
 
-        # This only applies if one of the variable tokenizers
-        # is python-brace-format.
-        # FIXME: Generalize this.
+        # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains('python-brace-format'):
             return []
 
@@ -253,6 +247,11 @@ class MissingVarsLintRule(LintRule):
 
     def lint(self, vartok, linted_entry):
         msgs = []
+
+        # If there are no variable formats, skip this rule.
+        if not vartok.formats:
+            return []
+
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
@@ -443,6 +442,10 @@ class InvalidVarsLintRule(LintRule):
     desc = 'Checks for variables not in msgid, but in msgstr'
 
     def lint(self, vartok, linted_entry):
+        # If there are no variable formats, skip this rule.
+        if not vartok.formats:
+            return []
+
         msgs = []
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -263,7 +263,21 @@ class TestLint:
         # The rule that generates this error is excluded, so this error shouldn't show up.
         assert 'W501: one character variable name "o"' not in result.output
 
-    # FIXME: test --varformat on .po file
+    def test_varformat_no_value(self, runner, tmpdir):
+        po_file = build_po_string(
+            '#: foo/foo.py:5\n'
+            'msgid "Foo %(o)s baz"\n'
+            'msgstr ""\n')
+        fn = tmpdir.join('messages.pot')
+        fn.write(po_file)
+
+        result = runner.invoke(cli, ('lint', '--varformat', '', str(fn)))
+
+        assert result.exit_code == 0
+        # We're not looking at any variables, so we should never have a variable related warning.
+        assert 'W501: one character variable name "o"' not in result.output
+
+    # FIXME: test --varformat with values
 
     # FIXME: test --reporter
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -161,6 +161,16 @@ class TestBadFormatLintRule(LintRuleTestCase):
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+        linted_entry = build_linted_entry(
+            '#: foo/foo.py:5\n'
+            'msgid "%s foo"\n'
+            'msgstr "%a FOO"\n'
+        )
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
+
 
 class TestMalformedNoTypeLintRule(LintRuleTestCase):
     lintrule = MalformedNoTypeLintRule()
@@ -180,7 +190,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo}"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
     def test_python_var_with_space(self):
         linted_entry = build_linted_entry(
@@ -228,7 +238,19 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr "%(stars)s de %(user)s el %(date)s (%(locale)s)"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
+
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+
+        linted_entry = build_linted_entry(
+            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            'msgid "%(count)s view"\n'
+            'msgid_plural "%(count)s views"\n'
+            'msgstr[0] "%(count) zoo"\n')
+
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
 
 
 class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
@@ -292,6 +314,16 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'missing right curly-brace: {0]" excede el tamano de {'
         )
 
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+
+        linted_entry = build_linted_entry(
+            'msgid "Value for key \\"{0}\\" exceeds the length of {1}"\n'
+            'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n')
+
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
+
 
 class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
     lintrule = MalformedMissingLeftBraceLintRule()
@@ -338,6 +370,17 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
             msgs[0].msg ==
             'missing left curly-brace: }}'
         )
+
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+
+        linted_entry = build_linted_entry(
+            '#: kitsune/questions/templates/questions/question_details.html:14\n'
+            'msgid "{q} | {product} Support Forum"\n'
+            'msgstr "{q} | {product}} foo bar"\n')
+
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
 
 
 class TestMissingVarsLintRule(LintRuleTestCase):
@@ -471,6 +514,17 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'missing variables: %s'
         )
 
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+
+        linted_entry = build_linted_entry(
+            '#: kitsune/kbforums/feeds.py:23\n'
+            'msgid "Recently updated threads about %s"\n'
+            'msgstr "RECENTLY UPDATED THREADS"\n'
+        )
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
+
 
 class TestInvalidVarsLintRule(LintRuleTestCase):
     lintrule = InvalidVarsLintRule()
@@ -482,7 +536,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "Oof"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
         linted_entry = build_linted_entry(
             '#: foo/foo.py:5\n'
@@ -490,7 +544,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo}"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
     def test_invalid(self):
         linted_entry = build_linted_entry(
@@ -539,7 +593,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr[0] "{n} mooo"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
     def test_double_percent(self):
         # Double-percent shouldn't be picked up as a variable.
@@ -550,7 +604,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "more than 50%% of the traffic"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
     def test_urlencoded_urls(self):
         # urlencoding uses % and that shouldn't get picked up
@@ -562,7 +616,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
 
     def test_msgid_no_vars(self):
         linted_entry = build_linted_entry(
@@ -571,7 +625,17 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "http://it.wikipedia.org/wiki/Canvas_%28elemento_HTML%29"\n')
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
+        assert msgs == []
+
+    def test_varformat_empty(self):
+        vartok = VariableTokenizer([])
+        linted_entry = build_linted_entry(
+            '#: foo/foo.py:5\n'
+            'msgid "Foo {bar}"\n'
+            'msgstr "Oof: {foo}"\n')
+
+        msgs = self.lintrule.lint(vartok, linted_entry)
+        assert msgs == []
 
 
 class TestBlankLintRule(LintRuleTestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,6 +6,15 @@ from dennis.tools import (
 )
 
 
+def test_empty_tokenizer():
+    vartok = VariableTokenizer([])
+    assert vartok.contains('python-format') is False
+    assert vartok.tokenize('a b c d e') == ['a b c d e']
+    assert vartok.extract_tokens('a b c d e') == set()
+    assert vartok.is_token('{0}') is False
+    assert vartok.extract_variable_name('{0}') is None
+
+
 def test_python_tokenizing():
     vartok = VariableTokenizer(['python-format', 'python-brace-format'])
     data = [


### PR DESCRIPTION
This fixes th' --varformat flag fer both lint and translate to alloww fer
nay variable formats by passin' in an empty strin'.

Fixes #83