### PR TITLE
use unicode to fix crash

### DIFF
--- a/dennis/cmdline.py
+++ b/dennis/cmdline.py
@@ -279,7 +279,7 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
 
         if not quiet and not reporter:
             out(TERM.bold_green,
-                '>>> Working on: {fn}'.format(fn=fn),
+                u'>>> Working on: {fn}'.format(fn=fn),
                 TERM.normal)
 
         error_results = [res for res in results if res.kind == 'err']


### PR DESCRIPTION
Using Fedora 25 and French language:

$ .local/bin/dennis-cmd lint file.po 
dennis version 0.7
Oh no! Dennis has thrown an error while trying to do stuff.
Please write up a bug report with the specifics so that 
we can fix it.

https://github.com/willkg/dennis/issues

Here is some information you can copy and paste into the 
bug report:

---
Dennis: '0.7'
Python: '2.7.12 (default, Sep 29 2016, 12:52:02) \n[GCC 6.2.1 20160916 (Red Hat 6.2.1-2)]'
Command line: ['.local/bin/dennis-cmd', 'lint', 'T\xc3\xa9l\xc3\xa9chargements/dnf.po']
Traceback (most recent call last):
  File ".local/bin/dennis-cmd", line 11, in <module>
    sys.exit(click_run())
  File "/home/jb/.local/lib/python2.7/site-packages/dennis/cmdline.py", line 156, in click_run
    cli(obj={})
  File "/home/jb/.local/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/jb/.local/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/jb/.local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jb/.local/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jb/.local/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/jb/.local/lib/python2.7/site-packages/dennis/cmdline.py", line 282, in lint
    '>>> Working on: {fn}'.format(fn=fn),
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 10: ordinal not in range(128)