### PR TITLE
Fix filename printin'

### DIFF
--- a/dennis/cmdline.py
+++ b/dennis/cmdline.py
@@ -249,7 +249,8 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
     for fn in po_files:
         try:
             if not os.path.exists(fn):
-                raise click.UsageError('file "%s" does not exist.' % fn)
+                raise click.UsageError(u'File "{fn}" does not exist.'.format(
+                    fn=click.format_filename(fn)))
 
             if fn.endswith('.po'):
                 results = linter.verify_file(fn)
@@ -257,7 +258,8 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
                 results = templatelinter.verify_file(fn)
         except IOError as ioe:
             # This is not a valid .po file. So mark it as an error.
-            err('>>> Problem opening file: {fn}'.format(fn=fn))
+            err(u'>>> Problem opening file: {fn}'.format(
+                fn=click.format_filename(fn)))
             err(repr(ioe))
             out('')
 
@@ -279,7 +281,7 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
 
         if not quiet and not reporter:
             out(TERM.bold_green,
-                '>>> Working on: {fn}'.format(fn=fn),
+                u'>>> Working on: {fn}'.format(fn=click.format_filename(fn)),
                 TERM.normal)
 
         error_results = [res for res in results if res.kind == 'err']
@@ -414,16 +416,20 @@ def status(ctx, showuntranslated, showfuzzy, path):
     for fn in po_files:
         try:
             if not os.path.exists(fn):
-                raise IOError('File "{fn}" does not exist.'.format(fn=fn))
+                raise IOError(u'File "{fn}" does not exist.'.format(
+                    fn=click.format_filename(fn)))
 
             pofile = parse_pofile(fn)
         except IOError as ioe:
-            err('>>> Problem opening file: {fn}'.format(fn=fn))
+            err(u'>>> Problem opening file: {fn}'.format(
+                fn=click.format_filename(fn)))
             err(repr(ioe))
             continue
 
         out('')
-        out(TERM.bold_green, '>>> Working on: {fn}'.format(fn=fn), TERM.normal)
+        out(TERM.bold_green,
+            u'>>> Working on: {fn}'.format(fn=click.format_filename(fn)),
+            TERM.normal)
 
         out('Metadata:')
         for key in ('Language', 'Report-Msgid-Bugs-To', 'PO-Revision-Date',
@@ -531,7 +537,8 @@ def translate(ctx, varformat, pipeline, strings, path):
         # Check all the paths first
         for arg in path:
             if not os.path.exists(arg):
-                raise click.UsageError('file %s does not exist.' % arg)
+                raise click.UsageError(u'File {fn} does not exist.'.format(
+                    fn=click.format_filename(arg)))
 
         for arg in path:
             click.echo(translator.translate_file(arg))

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -123,7 +123,7 @@ class TestTranslate:
         result = runner.invoke(cli, ('translate', '-p', 'shouty', str(fn)))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
-        assert last_line == 'Error: file %s does not exist.' % str(fn)
+        assert last_line == 'Error: File %s does not exist.' % str(fn)
 
     def test_plurals(self, runner, tmpdir):
         po_file = build_po_string(
@@ -174,6 +174,17 @@ class TestLint:
         assert len(output_lines) == 1
         assert output_lines[0].startswith('dennis version')
 
+    def test_linting_non_ascii_filename(self, runner, tmpdir):
+        po_file = build_po_string(
+            '#: foo/foo.py:5\n'
+            'msgid "Foo %(foo)s bar baz"\n'
+            'msgstr "Foo %(bar)s"\n')
+        fn = tmpdir.join('T\xc3\xa9l\xc3\xa9chargements', 'messages.po')
+        fn.write(po_file, ensure=True)
+
+        result = runner.invoke(cli, ('lint', str(tmpdir)))
+        assert result.exit_code == 1
+
     def test_linting_fail(self, runner, tmpdir):
         po_file = build_po_string(
             '#: foo/foo.py:5\n'
@@ -198,7 +209,7 @@ class TestLint:
         result = runner.invoke(cli, ('lint', str(fn)))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
-        assert last_line == 'Error: file "%s" does not exist.' % str(fn)
+        assert last_line == 'Error: File "%s" does not exist.' % str(fn)
 
     def test_quiet(self, runner, tmpdir):
         po_file = build_po_string(


### PR DESCRIPTION
Dennis handl'd printin' non-ascii filenames poorly. This adds a test to check
one o' those cases and also fixes filename printin' across cmdnline.py.

Fixes #96.