### PR TITLE
reformat code with black; lint with flake8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = lf
 charset = utf-8
-max_line_length = 100
 
 [*.{,py}]
 indent_style = space
 indent_size = 4
+max_line_length = 89

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "Available rules:"
+	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:/'
+
+.PHONY: clean
+clean:  ## Clean build artifacts
+	rm -rf build dist dennis.egg-info .tox
+	rm -rf docs/_build/*
+	find dennis/ tests/ -name __pycache__ | xargs rm -rf
+	find dennis/ tests/ -name '*.pyc' | xargs rm -rf

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,8 @@ clean:  ## Clean build artifacts
 	rm -rf docs/_build/*
 	find dennis/ tests/ -name __pycache__ | xargs rm -rf
 	find dennis/ tests/ -name '*.pyc' | xargs rm -rf
+
+.PHONY: lint
+lint:  ## Lint and black reformat files
+	black --target-version=py35 dennis tests
+	flake8 dennis tests

--- a/dennis/__init__.py
+++ b/dennis/__init__.py
@@ -2,7 +2,7 @@
 # Examples:
 # * 1.0
 # * 1.0.dev0
-__version__ = '0.9.1.dev0'
+__version__ = "0.9.1.dev0"
 
 # Date in 'YYYYMMDD' or ''
-__releasedate__ = ''
+__releasedate__ = ""

--- a/dennis/cmdline.py
+++ b/dennis/cmdline.py
@@ -16,17 +16,13 @@ from dennis.tools import (
     Terminal,
     get_available_formats,
     parse_pofile,
-    withlines
+    withlines,
 )
-from dennis.translator import (
-    get_available_pipeline_parts,
-    InvalidPipeline,
-    Translator
-)
+from dennis.translator import get_available_pipeline_parts, InvalidPipeline, Translator
 
 
-USAGE = '%prog [options] [command] [command-options]'
-VERSION = 'dennis ' + __version__
+USAGE = "%prog [options] [command] [command-options]"
+VERSION = "dennis " + __version__
 
 # blessings.Terminal and our FauxTerminal don't maintain any state so
 # we can make it global
@@ -39,92 +35,76 @@ else:
 def utf8_args(fun):
     @wraps(fun)
     def _utf8_args(*args):
-        args = [part.encode('utf-8') for part in args]
+        args = [part.encode("utf-8") for part in args]
         return fun(*args)
+
     return _utf8_args
 
 
 def out(*s):
     for part in s:
         click.echo(part, nl=False)
-    click.echo('')
+    click.echo("")
 
 
 def err(*s):
     """Prints a single-line string to stderr."""
-    parts = [
-        TERM.bold_red,
-        'Error: '
-    ]
+    parts = [TERM.bold_red, "Error: "]
     parts.extend(s)
     parts.append(TERM.normal)
     for part in parts:
         click.echo(part, nl=False, err=True)
-    click.echo('')
+    click.echo("")
 
 
 def format_formats():
     formats = sorted(get_available_formats().items())
-    lines = [
-        'Available Variable Formats:',
-        '',
-        '\b',
-    ]
+    lines = ["Available Variable Formats:", "", "\b"]
     lines.extend(
-        ['{name:19}  {desc}'.format(name=name, desc=cls.desc)
-         for name, cls in formats]
+        ["{name:19}  {desc}".format(name=name, desc=cls.desc) for name, cls in formats]
     )
 
-    text = '\n'.join(lines) + '\n'
+    text = "\n".join(lines) + "\n"
     return text
 
 
 def format_pipeline_parts():
     parts = sorted(get_available_pipeline_parts().items())
-    lines = [
-        'Available Pipeline Parts:',
-        '',
-        '\b',
-    ]
+    lines = ["Available Pipeline Parts:", "", "\b"]
     lines.extend(
-        ['{name:13}  {desc}'.format(name=name, desc=cls.desc)
-         for name, cls in parts]
+        ["{name:13}  {desc}".format(name=name, desc=cls.desc) for name, cls in parts]
     )
-    text = '\n'.join(lines) + '\n'
+    text = "\n".join(lines) + "\n"
     return text
 
 
 def format_lint_rules():
     from dennis.linter import get_lint_rules
+
     rules = sorted(get_lint_rules().items())
-    lines = [
-        'Available Lint Rules:',
-        '',
-        '\b',
-    ]
+    lines = ["Available Lint Rules:", "", "\b"]
     lines.extend(
-        ['{num:6} {name}: {desc}'.format(num=num, name=cls.name,
-                                         desc=cls.desc)
-         for num, cls in rules]
+        [
+            "{num:6} {name}: {desc}".format(num=num, name=cls.name, desc=cls.desc)
+            for num, cls in rules
+        ]
     )
-    text = '\n'.join(lines) + '\n'
+    text = "\n".join(lines) + "\n"
     return text
 
 
 def format_lint_template_rules():
     from dennis.templatelinter import get_lint_rules
+
     rules = sorted(get_lint_rules().items())
-    lines = [
-        'Available Template Lint Rules:',
-        '',
-        '\b',
-    ]
+    lines = ["Available Template Lint Rules:", "", "\b"]
     lines.extend(
-        ['{num:6} {name}: {desc}'.format(num=num, name=cls.name,
-                                         desc=cls.desc)
-         for num, cls in rules]
+        [
+            "{num:6} {name}: {desc}".format(num=num, name=cls.name, desc=cls.desc)
+            for num, cls in rules
+        ]
     )
-    text = '\n'.join(lines) + '\n'
+    text = "\n".join(lines) + "\n"
     return text
 
 
@@ -136,9 +116,11 @@ def epilog(docstring):
     generated bits to the docstring.
 
     """
+
     def _epilog(fun):
         fun.__doc__ = dedent(fun.__doc__) + docstring
         return fun
+
     return _epilog
 
 
@@ -153,26 +135,38 @@ def cli():
 
 
 @cli.command()
-@click.option('--quiet/--no-quiet', default=False)
-@click.option('--color/--no-color', default=True)
-@click.option('--varformat', default='python-format,python-brace-format',
-              help=('Comma-separated list of variable formats. '
-                    'See Available Variable Formats.'))
-@click.option('--rules', default='',
-              help=('Comma-separated list of lint rules to use. '
-                    'Defaults to all rules. See Available Lint Rules.'))
-@click.option('--excluderules', default='',
-              help=('Comma-separated list of lint rules to exclude. '
-                    'Defaults to no rules excluded. See Available Lint Rules.'))
-@click.option('--reporter', default='',
-              help='Reporter to use for output.')
-@click.option('--errorsonly/--no-errorsonly', default=False,
-              help='Only print errors.')
-@click.argument('path', nargs=-1)
+@click.option("--quiet/--no-quiet", default=False)
+@click.option("--color/--no-color", default=True)
+@click.option(
+    "--varformat",
+    default="python-format,python-brace-format",
+    help=(
+        "Comma-separated list of variable formats. " "See Available Variable Formats."
+    ),
+)
+@click.option(
+    "--rules",
+    default="",
+    help=(
+        "Comma-separated list of lint rules to use. "
+        "Defaults to all rules. See Available Lint Rules."
+    ),
+)
+@click.option(
+    "--excluderules",
+    default="",
+    help=(
+        "Comma-separated list of lint rules to exclude. "
+        "Defaults to no rules excluded. See Available Lint Rules."
+    ),
+)
+@click.option("--reporter", default="", help="Reporter to use for output.")
+@click.option("--errorsonly/--no-errorsonly", default=False, help="Only print errors.")
+@click.argument("path", nargs=-1)
 @click.pass_context
-@epilog(format_formats() + '\n' +
-        format_lint_rules() + '\n' +
-        format_lint_template_rules())
+@epilog(
+    format_formats() + "\n" + format_lint_rules() + "\n" + format_lint_template_rules()
+)
 def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly, path):
     """
     Lints .po/.pot files for issues
@@ -185,7 +179,7 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
     global TERM
 
     if not quiet:
-        out('dennis version {version}'.format(version=__version__))
+        out("dennis version {version}".format(version=__version__))
 
     if not color:
         TERM = FauxTerminal()
@@ -193,10 +187,10 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
     # Make sure requested rules are valid
     all_rules = get_linter_rules(with_names=True)
     all_rules.update(get_template_linter_rules(with_names=True))
-    rules = [rule.strip() for rule in rules.split(',') if rule.strip()]
+    rules = [rule.strip() for rule in rules.split(",") if rule.strip()]
     invalid_rules = [rule for rule in rules if rule not in all_rules]
     if invalid_rules:
-        raise click.UsageError('invalid rules: %s.' % ', '.join(invalid_rules))
+        raise click.UsageError("invalid rules: %s." % ", ".join(invalid_rules))
 
     if not rules:
         rules = get_linter_rules()
@@ -204,33 +198,38 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
         rules = rules.keys()
 
     if excluderules:
-        excludes = [rule.strip() for rule in excluderules.split(',') if rule.strip()]
+        excludes = [rule.strip() for rule in excluderules.split(",") if rule.strip()]
         invalid_rules = [rule for rule in excludes if rule not in all_rules]
         if invalid_rules:
-            raise click.UsageError('invalid exclude rules: %s.' % ', '.join(invalid_rules))
+            raise click.UsageError(
+                "invalid exclude rules: %s." % ", ".join(invalid_rules)
+            )
 
         # Remove excluded rules
         rules = [rule for rule in rules if rule not in excludes]
 
     # Build linters and lint
-    linter = Linter(varformat.split(','), rules)
-    templatelinter = TemplateLinter(varformat.split(','), rules)
+    linter = Linter(varformat.split(","), rules)
+    templatelinter = TemplateLinter(varformat.split(","), rules)
 
     po_files = []
     for item in path:
         if os.path.isdir(item):
             for root, dirs, files in os.walk(item):
                 po_files.extend(
-                    [os.path.join(root, fn) for fn in files
-                     if fn.endswith(('.po', '.pot'))])
+                    [
+                        os.path.join(root, fn)
+                        for fn in files
+                        if fn.endswith((".po", ".pot"))
+                    ]
+                )
         else:
             po_files.append(item)
 
-    po_files = [os.path.abspath(fn) for fn in po_files
-                if fn.endswith(('.po', '.pot'))]
+    po_files = [os.path.abspath(fn) for fn in po_files if fn.endswith((".po", ".pot"))]
 
     if not po_files:
-        raise click.UsageError('nothing to work on. Use --help for help.')
+        raise click.UsageError("nothing to work on. Use --help for help.")
 
     files_to_errors = {}
     total_error_count = 0
@@ -240,19 +239,19 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
     for fn in po_files:
         try:
             if not os.path.exists(fn):
-                raise click.UsageError('File "{fn}" does not exist.'.format(
-                    fn=click.format_filename(fn)))
+                raise click.UsageError(
+                    'File "{fn}" does not exist.'.format(fn=click.format_filename(fn))
+                )
 
-            if fn.endswith('.po'):
+            if fn.endswith(".po"):
                 results = linter.verify_file(fn)
             else:
                 results = templatelinter.verify_file(fn)
         except IOError as ioe:
             # This is not a valid .po file. So mark it as an error.
-            err('>>> Problem opening file: {fn}'.format(
-                fn=click.format_filename(fn)))
+            err(">>> Problem opening file: {fn}".format(fn=click.format_filename(fn)))
             err(repr(ioe))
-            out('')
+            out("")
 
             # FIXME - should we track this separately as an invalid
             # file?
@@ -262,7 +261,7 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
 
         if errorsonly:
             # Go through and nix all the non-error LintMessages
-            results = [res for res in results if res.kind == 'err']
+            results = [res for res in results if res.kind == "err"]
 
         # We don't want to print output for files that are fine, so we
         # update the bookkeeping and move on.
@@ -271,12 +270,14 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
             continue
 
         if not quiet and not reporter:
-            out(TERM.bold_green,
-                '>>> Working on: {fn}'.format(fn=click.format_filename(fn)),
-                TERM.normal)
+            out(
+                TERM.bold_green,
+                ">>> Working on: {fn}".format(fn=click.format_filename(fn)),
+                TERM.normal,
+            )
 
-        error_results = [res for res in results if res.kind == 'err']
-        warning_results = [res for res in results if res.kind == 'warn']
+        error_results = [res for res in results if res.kind == "err"]
+        warning_results = [res for res in results if res.kind == "warn"]
 
         error_count = len(error_results)
         total_error_count += error_count
@@ -286,69 +287,75 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
 
         if not quiet:
             for msg in error_results:
-                if reporter == 'line':
-                    out(fn,
-                        ':',
+                if reporter == "line":
+                    out(
+                        fn,
+                        ":",
                         str(msg.poentry.linenum),
-                        ':',
-                        '0',
-                        ':',
+                        ":",
+                        "0",
+                        ":",
                         msg.code,
-                        ':',
-                        msg.msg)
-                else:
-                    out(TERM.bold_red,
-                        msg.code,
-                        ': ',
+                        ":",
                         msg.msg,
-                        TERM.normal)
+                    )
+                else:
+                    out(TERM.bold_red, msg.code, ": ", msg.msg, TERM.normal)
                     out(withlines(msg.poentry.linenum, msg.poentry.original))
-                    out('')
+                    out("")
 
         if not quiet and not errorsonly:
             for msg in warning_results:
-                if reporter == 'line':
-                    out(fn,
-                        ':',
+                if reporter == "line":
+                    out(
+                        fn,
+                        ":",
                         str(msg.poentry.linenum),
-                        ':',
-                        '0',
-                        ':',
+                        ":",
+                        "0",
+                        ":",
                         msg.code,
-                        ':',
-                        msg.msg)
-                else:
-                    out(TERM.bold_yellow,
-                        msg.code,
-                        ': ',
+                        ":",
                         msg.msg,
-                        TERM.normal)
+                    )
+                else:
+                    out(TERM.bold_yellow, msg.code, ": ", msg.msg, TERM.normal)
                     out(withlines(msg.poentry.linenum, msg.poentry.original))
-                    out('')
+                    out("")
 
         files_to_errors[fn] = (error_count, warning_count)
 
         if error_count > 0:
             total_files_with_errors += 1
 
-        if not quiet and reporter != 'line':
-            out('Totals')
+        if not quiet and reporter != "line":
+            out("Totals")
             if not errorsonly:
-                out('  Warnings: {warnings:5}'.format(warnings=warning_count))
-            out('  Errors:   {errors:5}\n'.format(errors=error_count))
+                out("  Warnings: {warnings:5}".format(warnings=warning_count))
+            out("  Errors:   {errors:5}\n".format(errors=error_count))
 
-    if len(po_files) > 1 and not quiet and reporter != 'line':
-        out('Final totals')
-        out('  Number of files examined:          {count:5}'.format(
-            count=len(po_files)))
-        out('  Total number of files with errors: {count:5}'.format(
-            count=total_files_with_errors))
+    if len(po_files) > 1 and not quiet and reporter != "line":
+        out("Final totals")
+        out(
+            "  Number of files examined:          {count:5}".format(count=len(po_files))
+        )
+        out(
+            "  Total number of files with errors: {count:5}".format(
+                count=total_files_with_errors
+            )
+        )
         if not errorsonly:
-            out('  Total number of warnings:          {count:5}'.format(
-                count=total_warning_count))
-        out('  Total number of errors:            {count:5}'.format(
-            count=total_error_count))
-        out('')
+            out(
+                "  Total number of warnings:          {count:5}".format(
+                    count=total_warning_count
+                )
+            )
+        out(
+            "  Total number of errors:            {count:5}".format(
+                count=total_error_count
+            )
+        )
+        out("")
 
         file_counts = [
             (counts[0], counts[1], fn.split(os.sep)[-3], fn.split(os.sep)[-1])
@@ -357,11 +364,11 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
 
         # If we're showing errors only, then don't talk about warnings.
         if errorsonly:
-            header = 'Errors  Filename'
-            line = ' {errors:5}  {locale} ({fn})'
+            header = "Errors  Filename"
+            line = " {errors:5}  {locale} ({fn})"
         else:
-            header = 'Warnings  Errors  Filename'
-            line = '   {warnings:5}   {errors:5}  {locale} ({fn})'
+            header = "Warnings  Errors  Filename"
+            line = "   {warnings:5}   {errors:5}  {locale} ({fn})"
 
         file_counts = list(reversed(sorted(file_counts)))
         printed_header = False
@@ -372,76 +379,85 @@ def lint(ctx, quiet, color, varformat, rules, excluderules, reporter, errorsonly
                 out(header)
                 printed_header = True
 
-            out(line.format(
-                warnings=warning_count, errors=error_count, fn=fn,
-                locale=locale))
+            out(
+                line.format(
+                    warnings=warning_count, errors=error_count, fn=fn, locale=locale
+                )
+            )
 
     # Return 0 if everything was fine or 1 if there were errors.
     ctx.exit(code=1 if total_error_count else 0)
 
 
 @cli.command()
-@click.option('--showuntranslated', is_flag=True, default=False,
-              help='Show untranslated strings')
-@click.option('--showfuzzy', is_flag=True, default=False,
-              help='Show fuzzy strings')
-@click.argument('path', nargs=-1, type=click.Path(exists=True))
+@click.option(
+    "--showuntranslated", is_flag=True, default=False, help="Show untranslated strings"
+)
+@click.option("--showfuzzy", is_flag=True, default=False, help="Show fuzzy strings")
+@click.argument("path", nargs=-1, type=click.Path(exists=True))
 @click.pass_context
 def status(ctx, showuntranslated, showfuzzy, path):
     """Show status of a .po file."""
-    out('dennis version {version}'.format(version=__version__))
+    out("dennis version {version}".format(version=__version__))
 
     po_files = []
     for item in path:
         if os.path.isdir(item):
             for root, dirs, files in os.walk(item):
                 po_files.extend(
-                    [os.path.join(root, fn) for fn in files
-                     if fn.endswith('.po')])
+                    [os.path.join(root, fn) for fn in files if fn.endswith(".po")]
+                )
         else:
             po_files.append(item)
 
-    po_files = [os.path.abspath(fn) for fn in po_files
-                if fn.endswith('.po')]
+    po_files = [os.path.abspath(fn) for fn in po_files if fn.endswith(".po")]
 
     for fn in po_files:
         try:
             if not os.path.exists(fn):
-                raise IOError('File "{fn}" does not exist.'.format(
-                    fn=click.format_filename(fn)))
+                raise IOError(
+                    'File "{fn}" does not exist.'.format(fn=click.format_filename(fn))
+                )
 
             pofile = parse_pofile(fn)
         except IOError as ioe:
-            err('>>> Problem opening file: {fn}'.format(
-                fn=click.format_filename(fn)))
+            err(">>> Problem opening file: {fn}".format(fn=click.format_filename(fn)))
             err(repr(ioe))
             continue
 
-        out('')
-        out(TERM.bold_green,
-            '>>> Working on: {fn}'.format(fn=click.format_filename(fn)),
-            TERM.normal)
+        out("")
+        out(
+            TERM.bold_green,
+            ">>> Working on: {fn}".format(fn=click.format_filename(fn)),
+            TERM.normal,
+        )
 
-        out('Metadata:')
-        for key in ('Language', 'Report-Msgid-Bugs-To', 'PO-Revision-Date',
-                    'Last-Translator', 'Language-Team', 'Plural-Forms'):
+        out("Metadata:")
+        for key in (
+            "Language",
+            "Report-Msgid-Bugs-To",
+            "PO-Revision-Date",
+            "Last-Translator",
+            "Language-Team",
+            "Plural-Forms",
+        ):
             if key in pofile.metadata and pofile.metadata[key]:
-                out('  ', key, ': ', pofile.metadata[key])
-        out('')
+                out("  ", key, ": ", pofile.metadata[key])
+        out("")
 
         if showuntranslated:
-            out('Untranslated strings:')
-            out('')
+            out("Untranslated strings:")
+            out("")
             for poentry in pofile.untranslated_entries():
                 out(withlines(poentry.linenum, poentry.original))
-                out('')
+                out("")
 
         if showfuzzy:
-            out('Fuzzy strings:')
-            out('')
+            out("Fuzzy strings:")
+            out("")
             for poentry in pofile.fuzzy_entries():
                 out(withlines(poentry.linenum, poentry.original))
-                out('')
+                out("")
 
         total_words = 0
         translated_words = 0
@@ -458,36 +474,44 @@ def status(ctx, showuntranslated, showfuzzy, path):
         fuzzy_total = len(pofile.fuzzy_entries())
         untranslated_total = len(pofile.untranslated_entries())
 
-        out('Statistics:')
-        out('  Total strings:             {}'.format(total_strings))
-        out('    Translated:              {}'.format(translated_total))
-        out('    Untranslated:            {}'.format(untranslated_total))
-        out('    Fuzzy:                   {}'.format(fuzzy_total))
-        out('  Total translateable words: {}'.format(total_words))
-        out('    Translated:              {}'.format(translated_words))
-        out('    Untranslated:            {}'.format(untranslated_words))
+        out("Statistics:")
+        out("  Total strings:             {}".format(total_strings))
+        out("    Translated:              {}".format(translated_total))
+        out("    Untranslated:            {}".format(untranslated_total))
+        out("    Fuzzy:                   {}".format(fuzzy_total))
+        out("  Total translateable words: {}".format(total_words))
+        out("    Translated:              {}".format(translated_words))
+        out("    Untranslated:            {}".format(untranslated_words))
         if untranslated_words == 0:
-            out('  Percentage:                100% COMPLETE!')
+            out("  Percentage:                100% COMPLETE!")
         else:
-            out('  Percentage:                {}%'.format(
-                pofile.percent_translated()))
+            out("  Percentage:                {}%".format(pofile.percent_translated()))
 
     ctx.exit(0)
 
 
 @cli.command()
-@click.option('--varformat', default='python-format,python-brace-format',
-              help=('Comma-separated list of variable types. '
-                    'See Available Variable Formats.'))
-@click.option('--pipeline', '-p', default='pirate',
-              help=('Comma-separated translate pipeline. See Available '
-                    'Pipeline Parts.'))
-@click.option('--strings', '-s', default=False, is_flag=True,
-              help='Command line args are strings to be translated')
-@click.argument('path', nargs=-1)
+@click.option(
+    "--varformat",
+    default="python-format,python-brace-format",
+    help=("Comma-separated list of variable types. " "See Available Variable Formats."),
+)
+@click.option(
+    "--pipeline",
+    "-p",
+    default="pirate",
+    help=("Comma-separated translate pipeline. See Available " "Pipeline Parts."),
+)
+@click.option(
+    "--strings",
+    "-s",
+    default=False,
+    is_flag=True,
+    help="Command line args are strings to be translated",
+)
+@click.argument("path", nargs=-1)
 @click.pass_context
-@epilog(format_formats() + '\n' +
-        format_pipeline_parts())
+@epilog(format_formats() + "\n" + format_pipeline_parts())
 def translate(ctx, varformat, pipeline, strings, path):
     """
     Translate a single string or .po file of strings.
@@ -498,15 +522,15 @@ def translate(ctx, varformat, pipeline, strings, path):
     file.
 
     """
-    if not (path and path[0] == '-'):
+    if not (path and path[0] == "-"):
         # We don't want to print this if they're piping to stdin
-        out('dennis version {version}'.format(version=__version__))
+        out("dennis version {version}".format(version=__version__))
 
     if not path:
-        raise click.UsageError('nothing to work on. Use --help for help.')
+        raise click.UsageError("nothing to work on. Use --help for help.")
 
     try:
-        translator = Translator(varformat.split(','), pipeline.split(','))
+        translator = Translator(varformat.split(","), pipeline.split(","))
     except InvalidPipeline as ipe:
         raise click.UsageError(ipe.args[0])
 
@@ -516,9 +540,9 @@ def translate(ctx, varformat, pipeline, strings, path):
             data = translator.translate_string(arg)
             out(data)
 
-    elif path[0] == '-':
+    elif path[0] == "-":
         # Read everything from stdin, then translate it
-        data = click.get_binary_stream('stdin').read()
+        data = click.get_binary_stream("stdin").read()
         data = translator.translate_string(data)
         out(data)
 
@@ -526,8 +550,9 @@ def translate(ctx, varformat, pipeline, strings, path):
         # Check all the paths first
         for arg in path:
             if not os.path.exists(arg):
-                raise click.UsageError('File {fn} does not exist.'.format(
-                    fn=click.format_filename(arg)))
+                raise click.UsageError(
+                    "File {fn} does not exist.".format(fn=click.format_filename(arg))
+                )
 
         for arg in path:
             click.echo(translator.translate_file(arg))
@@ -536,19 +561,18 @@ def translate(ctx, varformat, pipeline, strings, path):
 
 
 def exception_handler(exc_type, exc_value, exc_tb):
-    click.echo('Oh no! Dennis has thrown an error while trying to do stuff.')
-    click.echo('Please write up a bug report with the specifics so that ')
-    click.echo('we can fix it.')
-    click.echo('')
-    click.echo('https://github.com/willkg/dennis/issues')
-    click.echo('')
-    click.echo('Here is some information you can copy and paste into the ')
-    click.echo('bug report:')
-    click.echo('')
-    click.echo('---')
-    out('Dennis: ', repr(__version__))
-    out('Python: ', repr(sys.version))
-    out('Command line: ', repr(sys.argv))
-    click.echo(
-        ''.join(traceback.format_exception(exc_type, exc_value, exc_tb)))
-    click.echo('---')
+    click.echo("Oh no! Dennis has thrown an error while trying to do stuff.")
+    click.echo("Please write up a bug report with the specifics so that ")
+    click.echo("we can fix it.")
+    click.echo("")
+    click.echo("https://github.com/willkg/dennis/issues")
+    click.echo("")
+    click.echo("Here is some information you can copy and paste into the ")
+    click.echo("bug report:")
+    click.echo("")
+    click.echo("---")
+    out("Dennis: ", repr(__version__))
+    out("Python: ", repr(sys.version))
+    out("Command line: ", repr(sys.argv))
+    click.echo("".join(traceback.format_exception(exc_type, exc_value, exc_tb)))
+    click.echo("---")

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -6,19 +6,19 @@ from dennis.tools import (
     VariableTokenizer,
     all_subclasses,
     parse_dennis_note,
-    parse_pofile
+    parse_pofile,
 )
 
 
-IdString = namedtuple('IdString', ('msgid_fields', 'msgid_strings'))
+IdString = namedtuple("IdString", ("msgid_fields", "msgid_strings"))
 TranslatedString = namedtuple(
-    'TranslatedString',
-    ('msgid_fields', 'msgid_strings', 'msgstr_field', 'msgstr_string')
+    "TranslatedString",
+    ("msgid_fields", "msgid_strings", "msgstr_field", "msgstr_string"),
 )
 
 
-WARNING = 'warn'
-ERROR = 'err'
+WARNING = "warn"
+ERROR = "err"
 
 
 class HTMLParseError(Exception):
@@ -35,8 +35,9 @@ class LintMessage:
         self.poentry = poentry
 
     def __repr__(self):
-        return '<LintedMessage {} {}:{} {} {}>'.format(
-            self.kind, self.line, self.col, self.code, self.msg)
+        return "<LintedMessage {} {}:{} {} {}>".format(
+            self.kind, self.line, self.col, self.code, self.msg
+        )
 
 
 class LintedEntry:
@@ -48,10 +49,10 @@ class LintedEntry:
     def str(self):
         poentry = self.poentry
         if poentry.msgid_plural:
-            msgid_fields = ('msgid', 'msgid_plural')
+            msgid_fields = ("msgid", "msgid_plural")
             msgid_strings = (poentry.msgid, poentry.msgid_plural)
         else:
-            msgid_fields = ('msgid',)
+            msgid_fields = ("msgid",)
             msgid_strings = (poentry.msgid,)
 
         return IdString(msgid_fields, msgid_strings)
@@ -63,11 +64,11 @@ class LintedEntry:
 
         if not poentry.msgid_plural:
             strs.append(
-                TranslatedString(
-                    ['msgid'], [poentry.msgid], 'msgstr', poentry.msgstr))
+                TranslatedString(["msgid"], [poentry.msgid], "msgstr", poentry.msgstr)
+            )
 
         else:
-            msgid_fields = ('msgid', 'msgid_plural')
+            msgid_fields = ("msgid", "msgid_plural")
             msgid_strings = (poentry.msgid, poentry.msgid_plural)
 
             for key in sorted(poentry.msgstr_plural.keys()):
@@ -75,17 +76,19 @@ class LintedEntry:
                     TranslatedString(
                         msgid_fields,
                         msgid_strings,
-                        'msgstr[{}]'.format(key),
-                        poentry.msgstr_plural[key]))
+                        "msgstr[{}]".format(key),
+                        poentry.msgstr_plural[key],
+                    )
+                )
 
         # List of TranslatedStrings
         return strs
 
 
 class LintRule:
-    num = ''
-    name = ''
-    desc = ''
+    num = ""
+    name = ""
+    desc = ""
 
     def lint(self, vartok, linted_entry):
         """Takes a linted entry and generates LintMessages
@@ -96,27 +99,27 @@ class LintRule:
         :returns: list of LintMeessages or empty list
 
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class MalformedNoTypeLintRule(LintRule):
-    num = 'E101'
-    name = 'notype'
-    desc = '%(count) with no type at the end'
+    num = "E101"
+    name = "notype"
+    desc = "%(count) with no type at the end"
 
     def lint(self, vartok, linted_entry):
         msgs = []
 
         # This only applies if one of the variable tokenizers is python-format.
-        if not vartok.contains('python-format'):
+        if not vartok.contains("python-format"):
             return msgs
 
         malformed_re = re.compile(
-            r'(?:'
-            r'%'                          # %
-            r'[\(][^\)\s]+[\)]'           # things in parens or not
-            r'(?:(?=[^diouxefGgcrs])|$)'  # end of string or something that's not a format char
-            r')'
+            r"(?:"
+            r"%"  # %
+            r"[\(][^\)\s]+[\)]"  # things in parens or not
+            r"(?:(?=[^diouxefGgcrs])|$)"  # end of string or something that's not a format char
+            r")"
         )
 
         for trstr in linted_entry.strs:
@@ -130,27 +133,31 @@ class MalformedNoTypeLintRule(LintRule):
             malformed = [item.strip() for item in malformed]
             msgs.append(
                 LintMessage(
-                    ERROR, linted_entry.poentry.linenum, 0, self.num,
-                    'type missing: {}'.format(', '.join(malformed)),
-                    linted_entry.poentry)
+                    ERROR,
+                    linted_entry.poentry.linenum,
+                    0,
+                    self.num,
+                    "type missing: {}".format(", ".join(malformed)),
+                    linted_entry.poentry,
+                )
             )
 
         return msgs
 
 
 class MalformedMissingRightBraceLintRule(LintRule):
-    num = 'E102'
-    name = 'missingrightbrace'
-    desc = '{foo with missing }'
+    num = "E102"
+    name = "missingrightbrace"
+    desc = "{foo with missing }"
 
     def lint(self, vartok, linted_entry):
         msgs = []
 
         # This only applies if one of the variable tokenizers is python-brace-format.
-        if not vartok.contains('python-brace-format'):
+        if not vartok.contains("python-brace-format"):
             return []
 
-        malformed_re = re.compile(r'(?:\{[^\}]+(?:\{|$))')
+        malformed_re = re.compile(r"(?:\{[^\}]+(?:\{|$))")
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
@@ -163,28 +170,31 @@ class MalformedMissingRightBraceLintRule(LintRule):
             malformed = [item.strip() for item in malformed]
             msgs.append(
                 LintMessage(
-                    ERROR, linted_entry.poentry.linenum, 0, self.num,
-                    'missing right curly-brace: {}'.format(
-                        ', '.join(malformed)),
-                    linted_entry.poentry)
+                    ERROR,
+                    linted_entry.poentry.linenum,
+                    0,
+                    self.num,
+                    "missing right curly-brace: {}".format(", ".join(malformed)),
+                    linted_entry.poentry,
+                )
             )
 
         return msgs
 
 
 class MalformedMissingLeftBraceLintRule(LintRule):
-    num = 'E103'
-    name = 'missingleftbrace'
-    desc = 'foo} with missing {'
+    num = "E103"
+    name = "missingleftbrace"
+    desc = "foo} with missing {"
 
     def lint(self, vartok, linted_entry):
         msgs = []
 
         # This only applies if one of the variable tokenizers is python-brace-format.
-        if not vartok.contains('python-brace-format'):
+        if not vartok.contains("python-brace-format"):
             return []
 
-        malformed_re = re.compile(r'(?:(?:^|\})[^\{]*\})')
+        malformed_re = re.compile(r"(?:(?:^|\})[^\{]*\})")
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
@@ -197,58 +207,64 @@ class MalformedMissingLeftBraceLintRule(LintRule):
             malformed = [item.strip() for item in malformed]
             msgs.append(
                 LintMessage(
-                    ERROR, linted_entry.poentry.linenum, 0, self.num,
-                    'missing left curly-brace: {}'.format(
-                        ', '.join(malformed)),
-                    linted_entry.poentry)
+                    ERROR,
+                    linted_entry.poentry.linenum,
+                    0,
+                    self.num,
+                    "missing left curly-brace: {}".format(", ".join(malformed)),
+                    linted_entry.poentry,
+                )
             )
         return msgs
 
 
 class BadFormatLintRule(LintRule):
-    num = 'E104'
-    name = 'badformat'
-    desc = '% followed by a bad format character'
+    num = "E104"
+    name = "badformat"
+    desc = "% followed by a bad format character"
 
     def lint(self, vartok, linted_entry):
         msgs = []
 
         # This only applies if one of the variable tokenizers is python-format.
-        if not vartok.contains('python-format'):
+        if not vartok.contains("python-format"):
             return []
 
-        splitter = re.compile(r'(\%(?:.|$))')
+        splitter = re.compile(r"(\%(?:.|$))")
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
-            msgid_tokens = list(vartok.extract_tokens(' '.join(trstr.msgid_strings)))
+            msgid_tokens = list(vartok.extract_tokens(" ".join(trstr.msgid_strings)))
             if not msgid_tokens:
                 continue
             # FIXME: Pretty sure we can just check the first token because they'll
             # all have to be the same kind of thing.
             first_token = msgid_tokens[0]
-            if not (len(first_token) == 2 and first_token[0] == '%'):
+            if not (len(first_token) == 2 and first_token[0] == "%"):
                 continue
 
             for match in splitter.findall(trstr.msgstr_string):
-                if len(match) == 1 or match[1] not in '(diouxefGgcrs%':
+                if len(match) == 1 or match[1] not in "(diouxefGgcrs%":
                     msgs.append(
                         LintMessage(
-                            ERROR, linted_entry.poentry.linenum, 0, self.num,
-                            'bad format character: {}'.format(match),
-                            linted_entry.poentry
+                            ERROR,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num,
+                            "bad format character: {}".format(match),
+                            linted_entry.poentry,
                         )
                     )
         return msgs
 
 
 class MissingVarsLintRule(LintRule):
-    num = 'W202'
-    num_error = 'E202'
-    name = 'missingvars'
-    desc = 'Checks for variables in msgid, but missing in msgstr'
+    num = "W202"
+    num_error = "E202"
+    name = "missingvars"
+    desc = "Checks for variables in msgid, but missing in msgstr"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -268,39 +284,46 @@ class MissingVarsLintRule(LintRule):
                 # ignore.
                 continue
 
-            msgid_tokens = vartok.extract_tokens(' '.join(trstr.msgid_strings))
+            msgid_tokens = vartok.extract_tokens(" ".join(trstr.msgid_strings))
             msgstr_tokens = vartok.extract_tokens(trstr.msgstr_string)
 
             missing = msgid_tokens.difference(msgstr_tokens)
 
             if missing:
-                if (vartok.contains('python-format')
-                     and len([var for var in missing if len(var) == 2 and var[0] == '%'])):
+                if vartok.contains("python-format") and len(
+                    [var for var in missing if len(var) == 2 and var[0] == "%"]
+                ):
                     # If we're looking at python-format variables and one of these is a
                     # python-format variable like %s, then this is an error--not a warning.
                     msgs.append(
                         LintMessage(
-                            ERROR, linted_entry.poentry.linenum, 0, self.num_error,
-                            'missing variables: {}'.format(
-                                ', '.join(sorted(missing))),
-                            linted_entry.poentry)
+                            ERROR,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num_error,
+                            "missing variables: {}".format(", ".join(sorted(missing))),
+                            linted_entry.poentry,
+                        )
                     )
                 else:
                     # If this is not python-format variables, then this is just a warning.
                     msgs.append(
                         LintMessage(
-                            WARNING, linted_entry.poentry.linenum, 0, self.num,
-                            'missing variables: {}'.format(
-                                ', '.join(sorted(missing))),
-                            linted_entry.poentry)
+                            WARNING,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num,
+                            "missing variables: {}".format(", ".join(sorted(missing))),
+                            linted_entry.poentry,
+                        )
                     )
         return msgs
 
 
 class BlankLintRule(LintRule):
-    num = 'W301'
-    name = 'blank'
-    desc = 'Translated string is only whitespace'
+    num = "W301"
+    name = "blank"
+    desc = "Translated string is only whitespace"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -312,18 +335,22 @@ class BlankLintRule(LintRule):
             if trstr.msgstr_string.isspace():
                 msgs.append(
                     LintMessage(
-                        WARNING, linted_entry.poentry.linenum, 0, self.num,
-                        'translated string is solely whitespace',
-                        linted_entry.poentry)
+                        WARNING,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num,
+                        "translated string is solely whitespace",
+                        linted_entry.poentry,
+                    )
                 )
 
         return msgs
 
 
 class UnchangedLintRule(LintRule):
-    num = 'W302'
-    name = 'unchanged'
-    desc = 'Makes sure string is actually translated'
+    num = "W302"
+    name = "unchanged"
+    desc = "Makes sure string is actually translated"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -335,24 +362,29 @@ class UnchangedLintRule(LintRule):
             if trstr.msgstr_string in trstr.msgid_strings:
                 msgs.append(
                     LintMessage(
-                        WARNING, linted_entry.poentry.linenum, 0, self.num,
-                        'translated string is same as source string',
-                        linted_entry.poentry)
+                        WARNING,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num,
+                        "translated string is same as source string",
+                        linted_entry.poentry,
+                    )
                 )
 
         return msgs
 
 
 class MismatchedHTMLLintRule(LintRule):
-    num = 'W303'
-    num_error = 'W304'
-    name = 'html'
-    desc = 'Checks for matching html between source and translated strings'
+    num = "W303"
+    num_error = "W304"
+    name = "html"
+    desc = "Checks for matching html between source and translated strings"
 
     def lint(self, vartok, linted_entry):
         msgs = []
 
         from dennis.translator import HTMLExtractorTransform, Token
+
         html = HTMLExtractorTransform()
 
         def equiv(left, right):
@@ -364,8 +396,11 @@ class MismatchedHTMLLintRule(LintRule):
             :raises HTMLParseError: If it's invalid HTML.
 
             """
-            tokens = [token for token in html.transform(vartok, [Token(text)])
-                      if token.type == 'html' and not token.s.startswith('&')]
+            tokens = [
+                token
+                for token in html.transform(vartok, [Token(text)])
+                if token.type == "html" and not token.s.startswith("&")
+            ]
             return sorted(tokens, key=lambda token: token.s)
 
         for trstr in linted_entry.strs:
@@ -375,14 +410,16 @@ class MismatchedHTMLLintRule(LintRule):
             try:
                 msgid_parts = tokenize(trstr.msgid_strings[0])
             except HTMLParseError as exc:
-                errmsg = (
-                    'invalid html: msgid has invalid html {}'
-                    .format(exc)
-                )
+                errmsg = "invalid html: msgid has invalid html {}".format(exc)
                 msgs.append(
                     LintMessage(
-                        WARNING, linted_entry.poentry.linenum, 0,
-                        self.num_error, errmsg, linted_entry.poentry)
+                        WARNING,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num_error,
+                        errmsg,
+                        linted_entry.poentry,
+                    )
                 )
                 return msgs
 
@@ -393,20 +430,25 @@ class MismatchedHTMLLintRule(LintRule):
                 try:
                     msgid_plural_parts = tokenize(trstr.msgid_strings[1])
                 except HTMLParseError as exc:
-                    errmsg = (
-                        'invalid html: msgid_plural has invalid html {}'
-                        .format(exc)
+                    errmsg = "invalid html: msgid_plural has invalid html {}".format(
+                        exc
                     )
 
                     msgs.append(
                         LintMessage(
-                            WARNING, linted_entry.poentry.linenum, 0,
-                            self.num_error, errmsg, linted_entry.poentry)
+                            WARNING,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num_error,
+                            errmsg,
+                            linted_entry.poentry,
+                        )
                     )
                     return msgs
 
                 zipped_parts = zip_longest(
-                    msgid_parts, msgid_plural_parts, fillvalue=None)
+                    msgid_parts, msgid_plural_parts, fillvalue=None
+                )
 
                 for left, right in zipped_parts:
                     if not left or not right or not equiv(left, right):
@@ -415,36 +457,41 @@ class MismatchedHTMLLintRule(LintRule):
             try:
                 msgstr_parts = tokenize(trstr.msgstr_string)
             except HTMLParseError as exc:
-                errmsg = (
-                    'invalid html: msgstr has invalid html {}'
-                    .format(exc)
-                )
+                errmsg = "invalid html: msgstr has invalid html {}".format(exc)
                 msgs.append(
                     LintMessage(
-                        WARNING, linted_entry.poentry.linenum, 0,
-                        self.num_error, errmsg, linted_entry.poentry)
+                        WARNING,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num_error,
+                        errmsg,
+                        linted_entry.poentry,
+                    )
                 )
                 return msgs
 
-            for left, right in zip_longest(msgid_parts, msgstr_parts,
-                                           fillvalue=None):
+            for left, right in zip_longest(msgid_parts, msgstr_parts, fillvalue=None):
                 if not left or not right or not equiv(left, right):
                     msgs.append(
                         LintMessage(
-                            WARNING, linted_entry.poentry.linenum, 0, self.num,
+                            WARNING,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num,
                             'different html: "{}" vs. "{}"'.format(
-                                left.s if left else '',
-                                right.s if right else ''),
-                            linted_entry.poentry)
+                                left.s if left else "", right.s if right else ""
+                            ),
+                            linted_entry.poentry,
+                        )
                     )
                     break
         return msgs
 
 
 class InvalidVarsLintRule(LintRule):
-    num = 'E201'
-    name = 'invalidvars'
-    desc = 'Checks for variables not in msgid, but in msgstr'
+    num = "E201"
+    name = "invalidvars"
+    desc = "Checks for variables not in msgid, but in msgstr"
 
     def lint(self, vartok, linted_entry):
         # If there are no variable formats, skip this rule.
@@ -456,7 +503,7 @@ class InvalidVarsLintRule(LintRule):
             if not trstr.msgstr_string:
                 continue
 
-            msgid_tokens = vartok.extract_tokens(' '.join(trstr.msgid_strings))
+            msgid_tokens = vartok.extract_tokens(" ".join(trstr.msgid_strings))
             # If this is python-format or python-brace-format and there are
             # no tokens in the msgid, then "no tokens, no problem".
             if not msgid_tokens:
@@ -469,10 +516,13 @@ class InvalidVarsLintRule(LintRule):
             if invalid:
                 msgs.append(
                     LintMessage(
-                        ERROR, linted_entry.poentry.linenum, 0, self.num,
-                        'invalid variables: {}'.format(
-                            ', '.join(sorted(invalid))),
-                        linted_entry.poentry)
+                        ERROR,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num,
+                        "invalid variables: {}".format(", ".join(sorted(invalid))),
+                        linted_entry.poentry,
+                    )
                 )
         return msgs
 
@@ -510,7 +560,7 @@ class Linter:
 
         # Check the comment to see if what we should ignore.
         for lint_rule in self.rules:
-            if skip == '*' or lint_rule.num in skip:
+            if skip == "*" or lint_rule.num in skip:
                 continue
 
             msgs.extend(lint_rule.lint(self.vartok, linted_entry))

--- a/dennis/templatelinter.py
+++ b/dennis/templatelinter.py
@@ -2,22 +2,19 @@ from dennis.tools import (
     VariableTokenizer,
     all_subclasses,
     parse_dennis_note,
-    parse_pofile
+    parse_pofile,
 )
-from dennis.linter import (
-    LintedEntry,
-    LintMessage
-)
+from dennis.linter import LintedEntry, LintMessage
 
 
-WARNING = 'warn'
-ERROR = 'err'
+WARNING = "warn"
+ERROR = "err"
 
 
 class TemplateLintRule:
-    num = ''
-    name = ''
-    desc = ''
+    num = ""
+    name = ""
+    desc = ""
 
     def lint(self, vartok, linted_entry):
         """Takes a linted entry and adds errors and warnings
@@ -27,15 +24,15 @@ class TemplateLintRule:
         :arg linted_entry: the LintedEntry to work on
 
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class HardToReadNamesTLR(TemplateLintRule):
-    num = 'W500'
-    name = 'hardtoread'
-    desc = 'Looks for vars that are hard to read like o, O, 0, l, 1'
+    num = "W500"
+    name = "hardtoread"
+    desc = "Looks for vars that are hard to read like o, O, 0, l, 1"
 
-    hard_to_read = ('o', 'O', '0', 'l', '1')
+    hard_to_read = ("o", "O", "0", "l", "1")
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -47,25 +44,29 @@ class HardToReadNamesTLR(TemplateLintRule):
                 continue
 
             msgid_tokens = vartok.extract_tokens(s)
-            msgid_tokens = [vartok.extract_variable_name(token)
-                            for token in msgid_tokens]
+            msgid_tokens = [
+                vartok.extract_variable_name(token) for token in msgid_tokens
+            ]
 
             for token in msgid_tokens:
                 if token in self.hard_to_read:
                     msgs.append(
                         LintMessage(
-                            WARNING, linted_entry.poentry.linenum, 0, self.num,
-                            'hard to read variable name "{}"'.format(
-                                token),
-                            linted_entry.poentry)
+                            WARNING,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num,
+                            'hard to read variable name "{}"'.format(token),
+                            linted_entry.poentry,
+                        )
                     )
         return msgs
 
 
 class OneCharNamesTLR(TemplateLintRule):
-    num = 'W501'
-    name = 'onechar'
-    desc = 'Looks for one character variable names'
+    num = "W501"
+    name = "onechar"
+    desc = "Looks for one character variable names"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -76,25 +77,29 @@ class OneCharNamesTLR(TemplateLintRule):
                 continue
 
             msgid_tokens = vartok.extract_tokens(s)
-            msgid_tokens = [vartok.extract_variable_name(token)
-                            for token in msgid_tokens]
+            msgid_tokens = [
+                vartok.extract_variable_name(token) for token in msgid_tokens
+            ]
 
             for token in msgid_tokens:
                 if len(token) == 1 and token.isalpha():
                     msgs.append(
                         LintMessage(
-                            WARNING, linted_entry.poentry.linenum, 0, self.num,
-                            'one character variable name "{}"'.format(
-                                token),
-                            linted_entry.poentry)
+                            WARNING,
+                            linted_entry.poentry.linenum,
+                            0,
+                            self.num,
+                            'one character variable name "{}"'.format(token),
+                            linted_entry.poentry,
+                        )
                     )
         return msgs
 
 
 class MultipleUnnamedVarsTLR(TemplateLintRule):
-    num = 'W502'
-    name = 'unnamed'
-    desc = 'Looks for multiple unnamed variables'
+    num = "W502"
+    name = "unnamed"
+    desc = "Looks for multiple unnamed variables"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -105,15 +110,20 @@ class MultipleUnnamedVarsTLR(TemplateLintRule):
                 continue
 
             msgid_tokens = vartok.extract_tokens(s, unique=False)
-            msgid_tokens = [vartok.extract_variable_name(token)
-                            for token in msgid_tokens]
+            msgid_tokens = [
+                vartok.extract_variable_name(token) for token in msgid_tokens
+            ]
 
-            if msgid_tokens.count('') > 1:
+            if msgid_tokens.count("") > 1:
                 msgs.append(
                     LintMessage(
-                        WARNING, linted_entry.poentry.linenum, 0, self.num,
-                        'multiple variables with no name.',
-                        linted_entry.poentry)
+                        WARNING,
+                        linted_entry.poentry.linenum,
+                        0,
+                        self.num,
+                        "multiple variables with no name.",
+                        linted_entry.poentry,
+                    )
                 )
         return msgs
 
@@ -151,7 +161,7 @@ class TemplateLinter:
 
         # Check the comment to see if what we should ignore.
         for lint_rule in self.rules:
-            if skip == '*' or lint_rule.num in skip:
+            if skip == "*" or lint_rule.num in skip:
                 continue
 
             msgs.extend(lint_rule.lint(self.vartok, linted_entry))

--- a/dennis/tools.py
+++ b/dennis/tools.py
@@ -19,29 +19,30 @@ except ImportError:
 
 class Format:
     """Variable format base class"""
-    name = ''
-    desc = ''
-    regexp = ''
+
+    name = ""
+    desc = ""
+    regexp = ""
 
     identifier = None
 
     @classmethod
     def extract_variable_name(cls, text):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 # https://www.gnu.org/software/gettext/manual/html_node/python_002dformat.html#python_002dformat
 # https://docs.python.org/2/library/string.html#format-string-syntax
 class PythonBraceFormat(Format):
-    name = 'python-brace-format'
+    name = "python-brace-format"
     desc = 'Python brace format (e.g. "{0}", "{foo}")'
 
     regexp = (
         # {}, {0}, {foo}, {foo:bar}, {foo:bar baz}
-        r'(?:\{[^\}]*?\})'
+        r"(?:\{[^\}]*?\})"
     )
 
-    identifier = re.compile(r'\{([^!:\}]*)')
+    identifier = re.compile(r"\{([^!:\}]*)")
 
     @classmethod
     def extract_variable_name(cls, text):
@@ -53,7 +54,7 @@ class PythonBraceFormat(Format):
 # https://www.gnu.org/software/gettext/manual/html_node/python_002dformat.html#python_002dformat
 # https://docs.python.org/2/library/stdtypes.html#string-formatting-operations
 class PythonFormat(Format):
-    name = 'python-format'
+    name = "python-format"
     desc = 'Python percent format (e.g. "%s", "%(foo)s")'
 
     regexp = (
@@ -61,29 +62,25 @@ class PythonFormat(Format):
         # Note: This doesn't support %E or %F because of problems
         # with false positives and urlencoding. Theoretically those
         # aren't getting used in gettext contexts anyhow.
-        r'(?:%(?:[(]\S+?[)])?[#0+-]?[\.\d\*]*[hlL]?[diouxefGgcrs])'
+        r"(?:%(?:[(]\S+?[)])?[#0+-]?[\.\d\*]*[hlL]?[diouxefGgcrs])"
     )
 
     identifier = re.compile(
-        r'%'
-        r'(?:' + r'\((\S+?)\)' + r')?'
-        r'[#0+-]?[\.\d\*]*[hlL]?[diouxefGgcrs]'
+        r"%" r"(?:" + r"\((\S+?)\)" + r")?" r"[#0+-]?[\.\d\*]*[hlL]?[diouxefGgcrs]"
     )
 
     @classmethod
     def extract_variable_name(cls, text):
         identifier = cls.identifier.match(text)
         if identifier:
-            return identifier.group(1) or ''
+            return identifier.group(1) or ""
 
 
 def get_available_formats():
     return {
         thing.name: thing
         for name, thing in globals().items()
-        if (name.endswith('Format')
-            and issubclass(thing, Format)
-            and thing.name)
+        if (name.endswith("Format") and issubclass(thing, Format) and thing.name)
     }
 
 
@@ -121,14 +118,11 @@ class VariableTokenizer:
                 try:
                     self.formats.append(all_formats[fmt])
                 except KeyError:
-                    raise UnknownFormat(
-                        '{} is not a known variable format'.format(fmt))
+                    raise UnknownFormat("{} is not a known variable format".format(fmt))
 
             # Generate variable regexp
             self.vars_re = re.compile(
-                r'(' +
-                '|'.join([vt.regexp for vt in self.formats]) +
-                r')'
+                r"(" + "|".join([vt.regexp for vt in self.formats]) + r")"
             )
 
     def contains(self, fmt):
@@ -160,7 +154,7 @@ class VariableTokenizer:
                 tokens = set(tokens)
             return tokens
         except TypeError:
-            print('TYPEERROR: {}'.format(repr(text)))
+            print("TYPEERROR: {}".format(repr(text)))
 
     def is_token(self, text):
         """Is this text a variable?"""
@@ -184,7 +178,7 @@ def all_subclasses(cls):
 # Matches:
 # "dennis-ignore: *" to skip all the rules
 # "dennis-ignore: E201,..." to ignore specific rules
-DENNIS_NOTE_RE = re.compile(r'dennis-ignore:\s+(\*|[EW0-9,]+)')
+DENNIS_NOTE_RE = re.compile(r"dennis-ignore:\s+(\*|[EW0-9,]+)")
 
 
 def parse_dennis_note(text):
@@ -197,10 +191,10 @@ def parse_dennis_note(text):
         return []
 
     match = match.group(1).strip()
-    if match == '*':
-        return '*'
+    if match == "*":
+        return "*"
 
-    return [item for item in match.split(',') if item]
+    return [item for item in match.split(",") if item]
 
 
 def parse_pofile(fn_or_string):
@@ -229,8 +223,8 @@ def parse_pofile(fn_or_string):
     # accurately print out what was in the pofile because polib will
     # reassembled what it parsed, but it's not the same.
     if _is_file(fn_or_string):
-        enc = detect_encoding(fn_or_string, 'pofile')
-        fp = io.open(fn_or_string, 'rt', encoding=enc)
+        enc = detect_encoding(fn_or_string, "pofile")
+        fp = io.open(fn_or_string, "rt", encoding=enc)
     else:
         fp = fn_or_string.splitlines(True)
 
@@ -240,16 +234,16 @@ def parse_pofile(fn_or_string):
         # Grab the lines that make up the poentry.
         # Note: linenum is 1-based, so we convert it to 0-based.
         try:
-            lines = fp[poentry.linenum-1:entries[i+1].linenum-1]
+            lines = fp[poentry.linenum - 1 : entries[i + 1].linenum - 1]
         except IndexError:
-            lines = fp[poentry.linenum-1:]
+            lines = fp[poentry.linenum - 1 :]
 
         # Nix blank lines at the end.
         while lines and not lines[-1].strip():
             lines.pop()
 
         # Join them and voila!
-        poentry.original = ''.join(lines)
+        poentry.original = "".join(lines)
 
     return parsed_pofile
 
@@ -259,9 +253,9 @@ def withlines(linenum, poentry_text):
     start = linenum
     new_text = []
 
-    lines_with_nums = zip(range(start, start+100), poentry_text.splitlines())
+    lines_with_nums = zip(range(start, start + 100), poentry_text.splitlines())
 
     for line_no, line in lines_with_nums:
-        new_text.append(str(line_no) + ':' + str(line))
+        new_text.append(str(line_no) + ":" + str(line))
 
-    return '\n'.join(new_text)
+    return "\n".join(new_text)

--- a/dennis/translator.py
+++ b/dennis/translator.py
@@ -13,13 +13,13 @@ DEBUG = False
 
 def debug(*args):
     if DEBUG:
-        print(' '.join([str(arg) for arg in args]))
+        print(" ".join([str(arg) for arg in args]))
 
 
 class Token:
-    def __init__(self, s, type='text', mutable=True):
+    def __init__(self, s, type="text", mutable=True):
         if not isinstance(s, str):
-            s = s.decode('utf-8')
+            s = s.decode("utf-8")
         self.s = s
         self.type = type
         self.mutable = mutable
@@ -28,7 +28,7 @@ class Token:
         return self.s
 
     def __repr__(self):
-        return '<{} {}>'.format(self.type, repr(self.s))
+        return "<{} {}>".format(self.type, repr(self.s))
 
     def __eq__(self, token):
         return (
@@ -42,8 +42,8 @@ class Token:
 
 
 class Transform:
-    name = ''
-    desc = ''
+    name = ""
+    desc = ""
 
     def transform(self, vartok, token_stream):
         """Takes a token stream and returns a token stream
@@ -56,20 +56,20 @@ class Transform:
         :return: iterable of transformed tokens
 
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class EmptyTransform(Transform):
-    name = 'empty'
-    desc = 'Returns empty strings.'
+    name = "empty"
+    desc = "Returns empty strings."
 
     def transform(self, vartok, token_stream):
-        return [Token('')]
+        return [Token("")]
 
 
 class DoubleTransform(Transform):
-    name = 'double'
-    desc = 'Doubles all vowels in a string.'
+    name = "double"
+    desc = "Doubles all vowels in a string."
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -79,17 +79,17 @@ class DoubleTransform(Transform):
                 continue
 
             s = token.s
-            for char in 'aeiouyAEIOUY':
+            for char in "aeiouyAEIOUY":
                 s = s.replace(char, char + char)
 
-            new_tokens.append(Token(''.join(s)))
+            new_tokens.append(Token("".join(s)))
 
         return new_tokens
 
 
 class XXXTransform(Transform):
-    name = 'xxx'
-    desc = 'Adds xxx before and after lines in a string.'
+    name = "xxx"
+    desc = "Adds xxx before and after lines in a string."
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -102,10 +102,10 @@ class XXXTransform(Transform):
             s = token.s
             for line in s.splitlines(True):
                 line, ending = self.split_ending(line)
-                line = 'xxx' + line + 'xxx' + ending
+                line = "xxx" + line + "xxx" + ending
                 new_s.append(line)
 
-            new_tokens.append(Token(''.join(new_s)))
+            new_tokens.append(Token("".join(new_s)))
 
         return new_tokens
 
@@ -116,17 +116,17 @@ class XXXTransform(Transform):
                 ending.insert(0, s[-1])
                 s = s[:-1]
             else:
-                return s, ''.join(ending)
+                return s, "".join(ending)
 
-        return '', ''.join(ending)
+        return "", "".join(ending)
 
 
 class HahaTransform(Transform):
-    name = 'haha'
-    desc = 'Adds haha! before sentences in a string.'
+    name = "haha"
+    desc = "Adds haha! before sentences in a string."
 
     def transform(self, vartok, token_stream):
-        haha = 'Haha\u2757'
+        haha = "Haha\u2757"
 
         new_tokens = []
         for token in token_stream:
@@ -134,27 +134,27 @@ class HahaTransform(Transform):
                 new_tokens.append(token)
                 continue
 
-            new_s = [haha + ' ']
+            new_s = [haha + " "]
 
             for i, c in enumerate(token.s):
-                if c in ('.!?'):
+                if c in (".!?"):
                     try:
-                        if token.s[i+1] == ' ':
+                        if token.s[i + 1] == " ":
                             new_s.append(c)
-                            new_s.append(' ')
+                            new_s.append(" ")
                             new_s.append(haha)
                             continue
                     except IndexError:
                         pass
-                if c == '\n':
+                if c == "\n":
                     new_s.append(c)
                     new_s.append(haha)
-                    new_s.append(' ')
+                    new_s.append(" ")
                     continue
 
                 new_s.append(c)
 
-            new_tokens.append(Token(''.join(new_s)))
+            new_tokens.append(Token("".join(new_s)))
 
         return new_tokens
 
@@ -165,14 +165,14 @@ class HahaTransform(Transform):
                 ending.insert(0, s[-1])
                 s = s[:-1]
             else:
-                return s, ''.join(ending)
+                return s, "".join(ending)
 
-        return '', ''.join(ending)
+        return "", "".join(ending)
 
 
 class AngleQuoteTransform(XXXTransform):
-    name = 'anglequote'
-    desc = 'Encloses string in unicode angle quotes.'
+    name = "anglequote"
+    desc = "Encloses string in unicode angle quotes."
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -182,15 +182,15 @@ class AngleQuoteTransform(XXXTransform):
                 continue
 
             s, ending = self.split_ending(token.s)
-            s = '\u00ab' + s + '\u00bb' + ending
+            s = "\u00ab" + s + "\u00bb" + ending
             new_tokens.append(Token(s))
 
         return new_tokens
 
 
 class ShoutyTransform(Transform):
-    name = 'shouty'
-    desc = 'Translates into all caps.'
+    name = "shouty"
+    desc = "Translates into all caps."
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -205,8 +205,8 @@ class ShoutyTransform(Transform):
 
 
 class ReverseTransform(Transform):
-    name = 'reverse'
-    desc = 'Reverses strings for RTL.'
+    name = "reverse"
+    desc = "Reverses strings for RTL."
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -221,27 +221,23 @@ class ReverseTransform(Transform):
 
 
 class DubstepTransform(Transform):
-    name = 'dubstep'
-    desc = 'Translates into written form of dubstep.'
+    name = "dubstep"
+    desc = "Translates into written form of dubstep."
 
-    def bwaa(self, text=''):
+    def bwaa(self, text=""):
         """BWAAs based on how far into the string we are"""
         tl = len(text) % 40
 
         if tl < 7:
-            return 't-t-t-t'
+            return "t-t-t-t"
         if tl < 9:
-            return 'V\u221eP V\u221eP'
+            return "V\u221eP V\u221eP"
         if tl < 11:
-            return '....vvvVV'
+            return "....vvvVV"
         if tl < 13:
-            return 'BWAAAaaT'
+            return "BWAAAaaT"
 
-        return (
-            'B' +
-            ('W' * int(tl / 4)) +
-            ('A' * int(tl / 3)) +
-            ('a' * int(tl / 4)))
+        return "B" + ("W" * int(tl / 4)) + ("A" * int(tl / 3)) + ("a" * int(tl / 4))
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -255,20 +251,19 @@ class DubstepTransform(Transform):
 
             for i, c in enumerate(token.s):
                 # print i, c, new_string, current_string
-                if c == ' ':
+                if c == " ":
                     if i % 2:
-                        current_string.append(' ')
-                        current_string.append(
-                            self.bwaa(''.join(current_string)))
+                        current_string.append(" ")
+                        current_string.append(self.bwaa("".join(current_string)))
 
-                if c == '\n':
-                    new_string.append(''.join(current_string))
+                if c == "\n":
+                    new_string.append("".join(current_string))
                     current_string = []
 
-                elif c in ('.!?'):
+                elif c in (".!?"):
                     try:
-                        if token.s[i+1] == ' ':
-                            new_string.append(''.join(current_string))
+                        if token.s[i + 1] == " ":
+                            new_string.append("".join(current_string))
                             current_string = []
                     except IndexError:
                         pass
@@ -276,10 +271,10 @@ class DubstepTransform(Transform):
                 current_string.append(c)
 
             if current_string:
-                new_string.append(''.join(current_string))
+                new_string.append("".join(current_string))
 
-            new_string = ' '.join(new_string)
-            new_string = new_string + ' ' + self.bwaa(new_string) + '\u2757'
+            new_string = " ".join(new_string)
+            new_string = new_string + " " + self.bwaa(new_string) + "\u2757"
 
             new_tokens.append(Token(new_string))
 
@@ -289,53 +284,53 @@ class DubstepTransform(Transform):
 class ZombieTransform(Transform):
     # Inspired by
     # http://forum.rpg.net/showthread.php?218042-Necro-Urban-Dead-The-zombie-speech-project/
-    name = 'zombie'
-    desc = 'Zombie.'
+    name = "zombie"
+    desc = "Zombie."
 
     zombish = {
-        'c': 'ZZ',
-        'd': 'GB',
-        'e': 'HA',
-        'f': 'ZR',
-        'i': 'AR',
-        'j': 'GA',
-        'k': 'BG',
-        'l': 'MN',
-        'o': 'HR',
-        'p': 'BZ',
-        'q': 'GH',
-        'r': 'MZ',
-        's': 'RZ',
-        't': 'HG',
-        'u': 'NM',
-        'v': 'BB',
-        'w': 'ZM',
-        'x': 'ZB',
-        'y': 'RA',
+        "c": "ZZ",
+        "d": "GB",
+        "e": "HA",
+        "f": "ZR",
+        "i": "AR",
+        "j": "GA",
+        "k": "BG",
+        "l": "MN",
+        "o": "HR",
+        "p": "BZ",
+        "q": "GH",
+        "r": "MZ",
+        "s": "RZ",
+        "t": "HG",
+        "u": "NM",
+        "v": "BB",
+        "w": "ZM",
+        "x": "ZB",
+        "y": "RA",
     }
 
-    def last_bit(self, text=''):
+    def last_bit(self, text=""):
         tl = len(text) % 40
 
         if tl < 7:
-            return 'CZCPT!'
+            return "CZCPT!"
         if tl < 9:
-            return 'RAR!'
+            return "RAR!"
         if tl < 11:
-            return 'RARRR!!!'
+            return "RARRR!!!"
         if tl < 13:
-            return 'GRRRRRrrRR!!'
+            return "GRRRRRrrRR!!"
         if tl < 20:
-            return 'BR-R-R-RAINS!'
-        return ''
+            return "BR-R-R-RAINS!"
+        return ""
 
     def zombie_transform(self, text):
         if not text.strip():
             return text
 
-        new_string = ''.join([self.zombish.get(c, c) for c in text])
-        new_string = new_string.replace('.', '\u2757')
-        new_string = new_string.replace('!', '\u2757')
+        new_string = "".join([self.zombish.get(c, c) for c in text])
+        new_string = new_string.replace(".", "\u2757")
+        new_string = new_string.replace("!", "\u2757")
         return new_string
 
     def transform(self, vartok, token_stream):
@@ -352,9 +347,9 @@ class ZombieTransform(Transform):
                     part = self.zombie_transform(part)
                 new_string.append(part)
 
-            new_string = ''.join(new_string)
+            new_string = "".join(new_string)
             if new_string.strip():
-                new_string = new_string + ' ' + self.last_bit(new_string)
+                new_string = new_string + " " + self.last_bit(new_string)
                 new_string = new_string.strip()
             new_tokens.append(Token(new_string))
 
@@ -362,12 +357,12 @@ class ZombieTransform(Transform):
 
 
 class RedactedTransform(Transform):
-    name = 'redacted'
-    desc = 'Redacts everything.'
+    name = "redacted"
+    desc = "Redacts everything."
 
     def transform(self, vartok, token_stream):
-        redact_map = {c: 'X' for c in string.ascii_uppercase}
-        redact_map.update({c: 'x' for c in string.ascii_lowercase})
+        redact_map = {c: "X" for c in string.ascii_uppercase}
+        redact_map.update({c: "x" for c in string.ascii_lowercase})
 
         new_tokens = []
         for token in token_stream:
@@ -376,14 +371,14 @@ class RedactedTransform(Transform):
                 continue
 
             new_s = [redact_map.get(c, c) for c in token.s]
-            new_tokens.append(Token(''.join(new_s)))
+            new_tokens.append(Token("".join(new_s)))
 
         return new_tokens
 
 
 class PirateTransform(Transform):
-    name = 'pirate'
-    desc = 'Translates text into Pirate!'
+    name = "pirate"
+    desc = "Translates text into Pirate!"
 
     def transform(self, vartok, token_stream):
         new_tokens = []
@@ -393,7 +388,7 @@ class PirateTransform(Transform):
                 new_tokens.append(token)
                 continue
 
-            out = ''
+            out = ""
             for i, part in enumerate(vartok.tokenize(token.s)):
                 if i % 2 == 0:
                     out += self.pirate_transform(part)
@@ -404,45 +399,44 @@ class PirateTransform(Transform):
             # only if the string isn't entirely whitespace.
             if not self.is_whitespace(out):
                 s, ending = self.split_ending(out)
-                out = (s + ' ' + self.COLOR[len(out) % len(self.COLOR)] +
-                       ending)
+                out = s + " " + self.COLOR[len(out) % len(self.COLOR)] + ending
 
                 # This guarantees that every string has at least one
                 # unicode charater
-                if '!' not in out:
-                    out = out + '!'
+                if "!" not in out:
+                    out = out + "!"
 
                 # Replace all ! with related unicode character.
-                out = out.replace('!', '\u2757')
+                out = out.replace("!", "\u2757")
 
             new_tokens.append(Token(out))
 
         return new_tokens
 
     COLOR = [
-        'arr!',
-        'arrRRr!',
-        'arrRRRrrr!',
-        'matey!',
-        'me mateys!',
-        'ahoy!',
-        'aye!',
-        'ye scalleywag!',
-        'cap\'n!',
-        'yo-ho-ho!',
-        'shiver me timbers!',
-        'ye landlubbers!',
-        'prepare to be boarded!',
-        ]
+        "arr!",
+        "arrRRr!",
+        "arrRRRrrr!",
+        "matey!",
+        "me mateys!",
+        "ahoy!",
+        "aye!",
+        "ye scalleywag!",
+        "cap'n!",
+        "yo-ho-ho!",
+        "shiver me timbers!",
+        "ye landlubbers!",
+        "prepare to be boarded!",
+    ]
 
     def wc(self, c):
-        return c == '\'' or c in string.ascii_letters
+        return c == "'" or c in string.ascii_letters
 
     def nwc(self, c):
         return not self.wc(c)
 
     def is_whitespace(self, s):
-        return re.match('^\\s*$', s) is not None
+        return re.match("^\\s*$", s) is not None
 
     # List of transform rules. The tuples have:
     #
@@ -458,48 +452,44 @@ class PirateTransform(Transform):
         # INW?, NIW?, match, WC?, NW?, replacement
         # Anti-replacements: need these so that we make sure these words
         # don't get screwed up by later rules.
-        (False, True, 'need', False, True, 'need'),
-        (False, True, 'Need', False, True, 'Need'),
-
+        (False, True, "need", False, True, "need"),
+        (False, True, "Need", False, True, "Need"),
         # Replace entire words
-        (False, True, 'add-on', False, True, 'bilge rat'),
-        (False, True, 'add-ons', False, True, 'bilge rats'),
-        (False, True, 'are', False, True, 'bee'),
-        (False, True, 'browser', False, True, 'corsairr'),
-        (False, True, 'for', False, True, 'fer'),
-        (False, True, 'Hi', False, True, 'H\'ello'),
-        (False, True, 'my', False, True, 'me'),
-        (False, True, 'no', False, True, 'nay'),
-        (False, True, 'of', False, True, 'o\''),
-        (False, True, 'over', False, True, 'o\'err'),
-        (False, True, 'plugin', False, True, 'mug o\' grog'),
-        (False, True, 'plugins', False, True, 'mugs o\' grog'),
-        (False, True, 'program', False, True, 'Jolly Rogerr'),
-        (False, True, 'the', False, True, 'th\''),
-        (False, True, 'there', False, True, 'tharr'),
-        (False, True, 'want', False, True, 'wants'),
-        (False, True, 'where', False, True, '\'erre'),
-        (False, True, 'with', False, True, 'wit\''),
-        (False, True, 'yes', False, True, 'aye'),
-        (False, True, 'you', False, True, 'ye\''),
-        (False, True, 'You', False, True, 'Ye\''),
-        (False, True, 'your', False, True, 'yerr'),
-        (False, True, 'Your', False, True, 'Yerr'),
-
+        (False, True, "add-on", False, True, "bilge rat"),
+        (False, True, "add-ons", False, True, "bilge rats"),
+        (False, True, "are", False, True, "bee"),
+        (False, True, "browser", False, True, "corsairr"),
+        (False, True, "for", False, True, "fer"),
+        (False, True, "Hi", False, True, "H'ello"),
+        (False, True, "my", False, True, "me"),
+        (False, True, "no", False, True, "nay"),
+        (False, True, "of", False, True, "o'"),
+        (False, True, "over", False, True, "o'err"),
+        (False, True, "plugin", False, True, "mug o' grog"),
+        (False, True, "plugins", False, True, "mugs o' grog"),
+        (False, True, "program", False, True, "Jolly Rogerr"),
+        (False, True, "the", False, True, "th'"),
+        (False, True, "there", False, True, "tharr"),
+        (False, True, "want", False, True, "wants"),
+        (False, True, "where", False, True, "'erre"),
+        (False, True, "with", False, True, "wit'"),
+        (False, True, "yes", False, True, "aye"),
+        (False, True, "you", False, True, "ye'"),
+        (False, True, "You", False, True, "Ye'"),
+        (False, True, "your", False, True, "yerr"),
+        (False, True, "Your", False, True, "Yerr"),
         # Prefixes
-        (False, True, 'hel', True, False, '\'el'),
-        (False, True, 'Hel', True, False, '\'el'),
-
+        (False, True, "hel", True, False, "'el"),
+        (False, True, "Hel", True, False, "'el"),
         # Mid-word
-        (True, False, 'er', True, False, 'arr'),
-
+        (True, False, "er", True, False, "arr"),
         # Suffixes
-        (True, False, 'a', False, True, 'ar'),
-        (True, False, 'ed', False, True, '\'d'),
-        (True, False, 'ing', False, True, 'in\''),
-        (True, False, 'ort', False, True, 'arrt'),
-        (True, False, 'r', False, True, 'rr'),
-        (True, False, 'w', False, True, 'ww'),
+        (True, False, "a", False, True, "ar"),
+        (True, False, "ed", False, True, "'d"),
+        (True, False, "ing", False, True, "in'"),
+        (True, False, "ort", False, True, "arrt"),
+        (True, False, "r", False, True, "rr"),
+        (True, False, "w", False, True, "ww"),
     )
 
     def split_ending(self, s):
@@ -509,9 +499,9 @@ class PirateTransform(Transform):
                 ending.insert(0, s[-1])
                 s = s[:-1]
             else:
-                return s, ''.join(ending)
+                return s, "".join(ending)
 
-        return '', ''.join(ending)
+        return "", "".join(ending)
 
     def pirate_transform(self, s):
         """Transforms a token into Pirate.
@@ -527,7 +517,7 @@ class PirateTransform(Transform):
 
         # TODO: This is awful--better to do a real lexer
         while s:
-            if s.startswith(('.', '!', '?')):
+            if s.startswith((".", "!", "?")):
                 in_word = False
                 out.append(s[0])
                 s = s[1:]
@@ -538,16 +528,16 @@ class PirateTransform(Transform):
             for mem in self.TRANSFORM:
                 # Match inside a word? (Not a prefix.)
                 if in_word and not mem[0]:
-                    debug(mem, 'not in word')
+                    debug(mem, "not in word")
                     continue
 
                 # Not match inside a word? (Prefix.)
                 if not in_word and not mem[1]:
-                    debug(mem, 'in word')
+                    debug(mem, "in word")
                     continue
 
                 if not s.startswith(mem[2]):
-                    debug(mem, 'not match')
+                    debug(mem, "not match")
                     continue
 
                 # Check the character after the match to see if it's a
@@ -555,12 +545,12 @@ class PirateTransform(Transform):
                 try:
                     # WC: word character
                     if mem[3] and not self.wc(s[len(mem[2])]):
-                        debug(mem, 'not wc')
+                        debug(mem, "not wc")
                         continue
                 except IndexError:
                     # We don't count EOS as a word character.
                     if mem[3]:
-                        debug(mem, 'not wc')
+                        debug(mem, "not wc")
                         continue
 
                 # Check the character after the match to see if it's not a
@@ -568,16 +558,16 @@ class PirateTransform(Transform):
                 try:
                     # NW: not word character
                     if mem[4] and not self.nwc(s[len(mem[2])]):
-                        debug(mem, 'wc')
+                        debug(mem, "wc")
                         continue
                 except IndexError:
                     # We count EOS as a non-word character.
                     if not mem[4]:
-                        debug(mem, 'wc')
+                        debug(mem, "wc")
                         continue
 
                 out.append(mem[5])
-                s = s[len(mem[2]):]
+                s = s[len(mem[2]) :]
                 in_word = True
                 break
 
@@ -586,16 +576,16 @@ class PirateTransform(Transform):
                 out.append(s[0])
                 s = s[1:]
 
-        return ''.join(out)
+        return "".join(out)
 
 
 def collapse_whitespace(text):
-    return re.compile(r'\s+', re.UNICODE).sub(' ', text).strip()
+    return re.compile(r"\s+", re.UNICODE).sub(" ", text).strip()
 
 
 class HTMLExtractorTransform(HTMLParser, Transform):
-    name = 'html'
-    desc = 'Tokenizes HTML bits so only text is translated.'
+    name = "html"
+    desc = "Tokenizes HTML bits so only text is translated."
 
     def __init__(self):
         HTMLParser.__init__(self)
@@ -621,52 +611,51 @@ class HTMLExtractorTransform(HTMLParser, Transform):
 
     def handle_starttag(self, tag, attrs, closed=False):
         # style and script contents should be immutable
-        if tag in ('style', 'script'):
+        if tag in ("style", "script"):
             self.immutable_data_section = tag
 
         # We want to translate alt and title values, but that's
         # it. So this gets a little goofy looking token-wise.
 
-        s = '<' + tag
+        s = "<" + tag
         for name, val in attrs:
-            s += ' '
+            s += " "
             s += name
             s += '="'
 
-            if name in ['alt', 'title', 'placeholder']:
-                self.new_tokens.append(Token(s, 'html', False))
+            if name in ["alt", "title", "placeholder"]:
+                self.new_tokens.append(Token(s, "html", False))
                 if val:
                     self.new_tokens.append(Token(val))
-                s = ''
+                s = ""
             elif val:
                 s += val
             s += '"'
         if closed:
-            s += ' /'
-        s += '>'
+            s += " /"
+        s += ">"
 
         if s:
-            self.new_tokens.append(Token(s, 'html', False))
+            self.new_tokens.append(Token(s, "html", False))
 
     def handle_startendtag(self, tag, attrs):
         self.handle_starttag(tag, attrs, closed=True)
 
     def handle_endtag(self, tag):
         self.immutable_data_section = None
-        self.new_tokens.append(Token('</' + tag + '>', 'html', False))
+        self.new_tokens.append(Token("</" + tag + ">", "html", False))
 
     def handle_data(self, data):
         if self.immutable_data_section:
-            self.new_tokens.append(Token(data, self.immutable_data_section,
-                                         False))
+            self.new_tokens.append(Token(data, self.immutable_data_section, False))
         else:
             self.new_tokens.append(Token(collapse_whitespace(data)))
 
     def handle_charref(self, name):
-        self.new_tokens.append(Token('&#' + name + ';', 'html', False))
+        self.new_tokens.append(Token("&#" + name + ";", "html", False))
 
     def handle_entityref(self, name):
-        self.new_tokens.append(Token('&' + name + ';', 'html', False))
+        self.new_tokens.append(Token("&" + name + ";", "html", False))
 
 
 def get_available_pipeline_parts():
@@ -681,6 +670,7 @@ def get_available_pipeline_parts():
 
 class InvalidPipeline(Exception):
     """Raised when the pipeline spec contains invalid parts"""
+
     pass
 
 
@@ -691,14 +681,14 @@ def convert_pipeline(pipeline_spec):
     try:
         pipeline = [pipeline_parts[part] for part in pipeline_spec]
     except KeyError:
-        raise InvalidPipeline('pipeline "%s" is not valid' %
-                              ','.join(pipeline_spec))
+        raise InvalidPipeline('pipeline "%s" is not valid' % ",".join(pipeline_spec))
 
     return pipeline
 
 
 class Translator:
     """Translates a string using the specified pipeline"""
+
     def __init__(self, variable_formats, pipeline_spec):
         self.vartok = VariableTokenizer(variable_formats)
         self.pipeline_spec = pipeline_spec
@@ -715,7 +705,7 @@ class Translator:
             tokens = part.transform(self.vartok, tokens)
 
         # Join all the bits together
-        return ''.join([token.s for token in tokens])
+        return "".join([token.s for token in tokens])
 
     def translate_file(self, fname):
         """Translates the po file at fname
@@ -727,22 +717,20 @@ class Translator:
         po = polib.pofile(fname)
 
         # FIXME - This might be a bit goofy
-        po.metadata['Language'] = ",".join(self.pipeline_spec)
-        po.metadata['Plural-Forms'] = 'nplurals=2; plural= n != 1'
-        po.metadata['Content-Type'] = 'text/plain; charset=UTF-8'
+        po.metadata["Language"] = ",".join(self.pipeline_spec)
+        po.metadata["Plural-Forms"] = "nplurals=2; plural= n != 1"
+        po.metadata["Content-Type"] = "text/plain; charset=UTF-8"
         count = 0
         for entry in po:
             if entry.msgid_plural:
-                entry.msgstr_plural[0] = self.translate_string(
-                    entry.msgid)
-                entry.msgstr_plural[1] = self.translate_string(
-                    entry.msgid_plural)
+                entry.msgstr_plural[0] = self.translate_string(entry.msgid)
+                entry.msgstr_plural[1] = self.translate_string(entry.msgid_plural)
             else:
                 entry.msgstr = self.translate_string(entry.msgid)
 
-            if 'fuzzy' in entry.flags:
-                entry.flags.remove('fuzzy')  # clear the fuzzy flag
+            if "fuzzy" in entry.flags:
+                entry.flags.remove("fuzzy")  # clear the fuzzy flag
             count += 1
 
         po.save()
-        return '{}: Translated {} messages.'.format(fname, count)
+        return "{}: Translated {} messages.".format(fname, count)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,9 @@
 -e .
 
 # tools
+black==19.3b0 ; python_version >= '3.6'
 check-manifest==0.37
+flake8==3.7.8
 pytest==3.7.2
 pytest-wholenodeid==0.2
 Sphinx==1.7.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,15 @@
-[bdist_wheel]
-universal=1
+[flake8]
+ignore =
+    # E203: Whitespace before ':'; doesn't work with black
+    E203,
+    # E501: line too long
+    E501,
+    # W503: line break before operator; this doesn't work with black
+    W503
+exclude =
+    .git/,
+    __pycache__,
+    docs/,
+    build/,
+    dist/
+max-line-length = 88

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,9 +16,9 @@ msgstr ""
 
 
 def build_po_string(data):
-    return POFILE_HEADER + '\n' + data
+    return POFILE_HEADER + "\n" + data
 
 
 def nix_header(pot_file):
     """Nix the POT file header since it changes and we don't care"""
-    return pot_file[pot_file.find('\n\n')+2:]
+    return pot_file[pot_file.find("\n\n") + 2 :]

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -16,51 +16,49 @@ def runner():
 def build_key_val(text):
     pairs = {}
     for line in text.splitlines():
-        if ':' in line:
-            key, val = line.split(':', 1)
+        if ":" in line:
+            key, val = line.split(":", 1)
             pairs[key.strip()] = val.strip()
     return pairs
 
 
 class TestStatus:
     def test_help(self, runner):
-        result = runner.invoke(cli, ('status', '--help'))
+        result = runner.invoke(cli, ("status", "--help"))
         assert result.exit_code == 0
-        assert 'Usage' in result.output.splitlines()[0]
+        assert "Usage" in result.output.splitlines()[0]
 
     def test_status_untranslated(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('status', str(fn)))
+        result = runner.invoke(cli, ("status", str(fn)))
         assert result.exit_code == 0
 
         # FIXME: This would be a lot easier if the status was structured and parseable.
         pairs = build_key_val(result.output)
-        assert pairs['Total strings'] == '1'
-        assert pairs['Total translateable words'] == '3'
-        assert pairs['Percentage'] == '0%'
+        assert pairs["Total strings"] == "1"
+        assert pairs["Total translateable words"] == "3"
+        assert pairs["Percentage"] == "0%"
 
     def test_status_translated(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr "Feh"\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr "Feh"\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('status', str(fn)))
+        result = runner.invoke(cli, ("status", str(fn)))
         assert result.exit_code == 0
 
         # FIXME: This would be a lot easier if the status was structured and parseable.
         pairs = build_key_val(result.output)
-        assert pairs['Total strings'] == '1'
-        assert pairs['Total translateable words'] == '3'
-        assert pairs['Percentage'] == '100% COMPLETE!'
+        assert pairs["Total strings"] == "1"
+        assert pairs["Total translateable words"] == "3"
+        assert pairs["Percentage"] == "100% COMPLETE!"
 
     # FIXME: test --showuntranslated on .po file
 
@@ -69,37 +67,36 @@ class TestStatus:
 
 class TestTranslate:
     def test_help(self, runner):
-        result = runner.invoke(cli, ('translate', '--help'))
+        result = runner.invoke(cli, ("translate", "--help"))
         assert result.exit_code == 0
-        assert 'Usage' in result.output.splitlines()[0]
+        assert "Usage" in result.output.splitlines()[0]
 
     def test_strings(self, runner):
-        result = runner.invoke(cli, ('translate', '-p', 'shouty', '-s', 'ou812'))
+        result = runner.invoke(cli, ("translate", "-p", "shouty", "-s", "ou812"))
         assert result.exit_code == 0
-        assert 'OU812' in result.output
+        assert "OU812" in result.output
 
     def test_no_paths(self, runner):
-        result = runner.invoke(cli, ('translate', '-p', 'shouty'))
+        result = runner.invoke(cli, ("translate", "-p", "shouty"))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
-        assert last_line == 'Error: nothing to work on. Use --help for help.'
+        assert last_line == "Error: nothing to work on. Use --help for help."
 
     def test_pipe(self, runner):
-        result = runner.invoke(cli, ('translate', '-p', 'shouty', '-'), input='foo bar')
+        result = runner.invoke(cli, ("translate", "-p", "shouty", "-"), input="foo bar")
         assert result.exit_code == 0
-        assert result.output == 'FOO BAR\n'
+        assert result.output == "FOO BAR\n"
 
     def test_pipeline(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
         # Verify the last line is untranslated
         assert po_file.endswith('msgstr ""\n')
 
-        result = runner.invoke(cli, ('translate', '-p', 'shouty', str(fn)))
+        result = runner.invoke(cli, ("translate", "-p", "shouty", str(fn)))
         assert result.exit_code == 0
         last_line = fn.read().splitlines()[-1]
         # Verify the last line is now translated
@@ -107,180 +104,169 @@ class TestTranslate:
 
     def test_bad_pipeline(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('translate', '-p', 'triangle', str(fn)))
+        result = runner.invoke(cli, ("translate", "-p", "triangle", str(fn)))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
         assert last_line == 'Error: pipeline "triangle" is not valid'
 
     def test_nonexistent_file(self, runner, tmpdir):
-        fn = tmpdir.join('missingfile.po')
-        result = runner.invoke(cli, ('translate', '-p', 'shouty', str(fn)))
+        fn = tmpdir.join("missingfile.po")
+        result = runner.invoke(cli, ("translate", "-p", "shouty", str(fn)))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
-        assert last_line == 'Error: File %s does not exist.' % str(fn)
+        assert last_line == "Error: File %s does not exist." % str(fn)
 
     def test_plurals(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: test_project/base/views.py:12 test_project/base/views.py:22\n'
-            '#, python-format\n'
+            "#: test_project/base/views.py:12 test_project/base/views.py:22\n"
+            "#, python-format\n"
             'msgid "%(num)s apple"\n'
             'msgid_plural "%(num)s apples"\n'
             'msgstr[0] ""\n'
             'msgstr[1] ""\n'
         )
-        fn = tmpdir.join('messages.po')
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('translate', '-p', 'shouty', str(fn)))
+        result = runner.invoke(cli, ("translate", "-p", "shouty", str(fn)))
         assert result.exit_code == 0
         pot_file = nix_header(fn.read())
         # FIXME: This has the wrong variables, too. We need to fix that, too.
-        assert (
-            pot_file ==
-            dedent("""\
+        assert pot_file == dedent(
+            """\
             #: test_project/base/views.py:12 test_project/base/views.py:22
             #, python-format
             msgid "%(num)s apple"
             msgid_plural "%(num)s apples"
             msgstr[0] "%(NUM)S APPLE"
             msgstr[1] "%(NUM)S APPLES"
-            """)
+            """
         )
 
 
 class TestLint:
     def test_help(self, runner):
-        result = runner.invoke(cli, ('lint', '--help'))
+        result = runner.invoke(cli, ("lint", "--help"))
         assert result.exit_code == 0
-        assert 'Usage' in result.output.splitlines()[0]
+        assert "Usage" in result.output.splitlines()[0]
 
     def test_basic_linting(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr "Foo"\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr "Foo"\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', str(fn)))
+        result = runner.invoke(cli, ("lint", str(fn)))
         assert result.exit_code == 0
         output_lines = result.output.splitlines()
         assert len(output_lines) == 1
-        assert output_lines[0].startswith('dennis version')
+        assert output_lines[0].startswith("dennis version")
 
     def test_linting_non_ascii_filename(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(foo)s bar baz"\n'
-            'msgstr "Foo %(bar)s"\n')
-        fn = tmpdir.join('T\xc3\xa9l\xc3\xa9chargements', 'messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(foo)s bar baz"\n' 'msgstr "Foo %(bar)s"\n'
+        )
+        fn = tmpdir.join("T\xc3\xa9l\xc3\xa9chargements", "messages.po")
         fn.write(po_file, ensure=True)
 
-        result = runner.invoke(cli, ('lint', str(tmpdir)))
+        result = runner.invoke(cli, ("lint", str(tmpdir)))
         assert result.exit_code == 1
 
     def test_linting_fail(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(foo)s bar baz"\n'
-            'msgstr "Foo %(bar)s"\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(foo)s bar baz"\n' 'msgstr "Foo %(bar)s"\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', str(fn)))
+        result = runner.invoke(cli, ("lint", str(fn)))
         assert result.exit_code == 1
         output_lines = result.output.splitlines()
         assert len(output_lines) == 16
-        assert 'E201: invalid variables: %(bar)s' in result.output
+        assert "E201: invalid variables: %(bar)s" in result.output
 
     def test_no_files_to_work_on(self, runner):
-        result = runner.invoke(cli, ('lint', 'foo'))
+        result = runner.invoke(cli, ("lint", "foo"))
         assert result.exit_code == 2
-        assert 'nothing to work on.' in result.output
+        assert "nothing to work on." in result.output
 
     def test_nonexistent_file(self, runner, tmpdir):
-        fn = tmpdir.join('missingfile.po')
-        result = runner.invoke(cli, ('lint', str(fn)))
+        fn = tmpdir.join("missingfile.po")
+        result = runner.invoke(cli, ("lint", str(fn)))
         assert result.exit_code == 2
         last_line = result.output.splitlines()[-1]
         assert last_line == 'Error: File "%s" does not exist.' % str(fn)
 
     def test_quiet(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo bar baz"\n'
-            'msgstr "Foo"\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr "Foo"\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--quiet', str(fn)))
+        result = runner.invoke(cli, ("lint", "--quiet", str(fn)))
         assert result.exit_code == 0
-        assert result.output == ''
+        assert result.output == ""
 
     def test_rules(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(bar)s baz"\n'
-            'msgstr "FOO %(bar) BAZ"\n')
-        fn = tmpdir.join('messages.po')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(bar)s baz"\n' 'msgstr "FOO %(bar) BAZ"\n'
+        )
+        fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--rules', 'E101', str(fn)))
+        result = runner.invoke(cli, ("lint", "--rules", "E101", str(fn)))
         assert result.exit_code == 1
-        assert 'E101: type missing: %(bar)' in result.output
+        assert "E101: type missing: %(bar)" in result.output
 
     def test_template_rules(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(o)s baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.pot')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(o)s baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.pot")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--rules', 'W501', str(fn)))
+        result = runner.invoke(cli, ("lint", "--rules", "W501", str(fn)))
         assert result.exit_code == 0
         assert 'W501: one character variable name "o"' in result.output
 
     def test_nonexisting_rule(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(o)s baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.pot')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(o)s baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.pot")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--rules', 'foo', str(fn)))
+        result = runner.invoke(cli, ("lint", "--rules", "foo", str(fn)))
         assert result.exit_code == 2
-        assert 'Error: invalid rules: foo.' in result.output
+        assert "Error: invalid rules: foo." in result.output
 
     def test_excludes(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(o)s baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.pot')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(o)s baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.pot")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--excluderules', 'W501', str(fn)))
+        result = runner.invoke(cli, ("lint", "--excluderules", "W501", str(fn)))
         assert result.exit_code == 0
         # The rule that generates this error is excluded, so this error shouldn't show up.
         assert 'W501: one character variable name "o"' not in result.output
 
     def test_varformat_no_value(self, runner, tmpdir):
         po_file = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %(o)s baz"\n'
-            'msgstr ""\n')
-        fn = tmpdir.join('messages.pot')
+            "#: foo/foo.py:5\n" 'msgid "Foo %(o)s baz"\n' 'msgstr ""\n'
+        )
+        fn = tmpdir.join("messages.pot")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ('lint', '--varformat', '', str(fn)))
+        result = runner.invoke(cli, ("lint", "--varformat", "", str(fn)))
 
         assert result.exit_code == 0
         # We're not looking at any variables, so we should never have a variable related warning.

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -11,7 +11,7 @@ from dennis.linter import (
     InvalidVarsLintRule,
     UnchangedLintRule,
     LintedEntry,
-    Linter
+    Linter,
 )
 from dennis.templatelinter import (
     HardToReadNamesTLR,
@@ -24,15 +24,9 @@ from tests import build_po_string
 
 class LinterTest:
     def test_linter(self):
-        pofile = build_po_string(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "Oof"\n')
+        pofile = build_po_string("#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n')
 
-        linter = Linter(
-            ['python-format', 'python-brace-format'],
-            ['E201', 'W202']
-        )
+        linter = Linter(["python-format", "python-brace-format"], ["E201", "W202"])
         msgs = linter.verify_file(pofile)
 
         # No warnings or errors, so there are no messages.
@@ -40,16 +34,14 @@ class LinterTest:
 
     def test_linter_fuzzy_strings(self):
         pofile = build_po_string(
-            '#, fuzzy\n'
+            "#, fuzzy\n"
             '#~ msgid "Most Recent Message"\n'
             '#~ msgid_plural "Last %(count)s Messages"\n'
             '#~ msgstr[0] "Les {count} derniers messages"\n'
-            '#~ msgstr[1] "Les {count} derniers messages"\n')
-
-        linter = Linter(
-            ['python-format', 'python-brace-format'],
-            ['E201', 'W202']
+            '#~ msgstr[1] "Les {count} derniers messages"\n'
         )
+
+        linter = Linter(["python-format", "python-brace-format"], ["E201", "W202"])
         msgs = linter.verify_file(pofile)
 
         # There were no non-fuzzy strings, so nothing to lint.
@@ -57,16 +49,14 @@ class LinterTest:
 
     def test_linter_untranslated_strings(self):
         pofile = build_po_string(
-            '#, fuzzy\n'
+            "#, fuzzy\n"
             '#~ msgid "Most Recent Message"\n'
             '#~ msgid_plural "Last %(count)s Messages"\n'
             '#~ msgstr[0] ""\n'
-            '#~ msgstr[1] ""\n')
-
-        linter = Linter(
-            ['python-format', 'python-brace-format'],
-            ['E201', 'W202']
+            '#~ msgstr[1] ""\n'
         )
+
+        linter = Linter(["python-format", "python-brace-format"], ["E201", "W202"])
         msgs = linter.verify_file(pofile)
 
         # There were no translated strings, so nothing to lint.
@@ -80,7 +70,7 @@ def build_linted_entry(po_data):
 
 
 class LintRuleTestCase:
-    vartok = VariableTokenizer(['python-format', 'python-brace-format'])
+    vartok = VariableTokenizer(["python-format", "python-brace-format"])
 
 
 class TestBadFormatLintRule(LintRuleTestCase):
@@ -88,50 +78,40 @@ class TestBadFormatLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "FOO"\n'
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "FOO"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo %s"\n'
-            'msgstr "FOO %s"\n'
+            "#: foo/foo.py:5\n" 'msgid "Foo %s"\n' 'msgstr "FOO %s"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
     def test_bad_format_character(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "%s foo"\n'
-            'msgstr "%a FOO"\n'
+            "#: foo/foo.py:5\n" 'msgid "%s foo"\n' 'msgstr "%a FOO"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E104'
-        assert msgs[0].msg == 'bad format character: %a'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E104"
+        assert msgs[0].msg == "bad format character: %a"
 
     def test_last_character(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "foo %s"\n'
-            'msgstr "FOO %"\n'
+            "#: foo/foo.py:5\n" 'msgid "foo %s"\n' 'msgstr "FOO %"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E104'
-        assert msgs[0].msg == 'bad format character: %'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E104"
+        assert msgs[0].msg == "bad format character: %"
 
     def test_handle_double_percent(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "%% foo"\n'
-            'msgstr "%% FOO"\n'
+            "#: foo/foo.py:5\n" 'msgid "%% foo"\n' 'msgstr "%% FOO"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -140,9 +120,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
         # If there are no vars in the msgid, then we don't want to throw errors about stuff we see
         # in the translated string because it's likely it's not being interpolated by %.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "foo 50% omg"\n'
-            'msgstr "FOO 50% OMG"\n'
+            "#: foo/foo.py:5\n" 'msgid "foo 50% omg"\n' 'msgstr "FOO 50% OMG"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -151,7 +129,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
         # If the formatting token is actually part of another formatting token, then we want to
         # ignore it.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "foo {startdate:%Y-%m-%d %H:%M} bar"\n'
             'msgstr "FOO {startdate:%Y-%m-%d %H:%M} BAR"\n'
         )
@@ -161,9 +139,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "%s foo"\n'
-            'msgstr "%a FOO"\n'
+            "#: foo/foo.py:5\n" 'msgid "%s foo"\n' 'msgstr "%a FOO"\n'
         )
         msgs = self.lintrule.lint(vartok, linted_entry)
         assert msgs == []
@@ -174,65 +150,66 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "Oof"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {foo}"\n'
-            'msgstr "Oof: {foo}"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
     def test_python_var_with_space(self):
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "%(count)s view"\n'
             'msgid_plural "%(count)s views"\n'
-            'msgstr[0] "%(count) zoo"\n')
+            'msgstr[0] "%(count) zoo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E101'
-        assert msgs[0].msg == 'type missing: %(count)'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E101"
+        assert msgs[0].msg == "type missing: %(count)"
 
     def test_python_var_end_of_line(self):
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "%(count)s"\n'
             'msgid_plural "%(count)s"\n'
-            'msgstr[0] "%(count)"\n')
+            'msgstr[0] "%(count)"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E101'
-        assert msgs[0].msg == 'type missing: %(count)'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E101"
+        assert msgs[0].msg == "type missing: %(count)"
 
     def test_python_var_punctuation(self):
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "%(count)s"\n'
             'msgstr "%(count)!"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E101'
-        assert msgs[0].msg == 'type missing: %(count)'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E101"
+        assert msgs[0].msg == "type missing: %(count)"
 
     def test_python_var_not_malformed(self):
         """This used to be a false positive"""
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "%(stars)s by %(user)s on %(date)s (%(locale)s)"\n'
-            'msgstr "%(stars)s de %(user)s el %(date)s (%(locale)s)"\n')
+            'msgstr "%(stars)s de %(user)s el %(date)s (%(locale)s)"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -241,10 +218,11 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
         vartok = VariableTokenizer([])
 
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "%(count)s view"\n'
             'msgid_plural "%(count)s views"\n'
-            'msgstr[0] "%(count) zoo"\n')
+            'msgstr[0] "%(count) zoo"\n'
+        )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
         assert msgs == []
@@ -255,68 +233,63 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
 
     def test_python_var_missing_right_curly_brace(self):
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "{foo} bar is the best thing ever"\n'
-            'msgstr "{foo) bar is the best thing ever"\n')
+            'msgstr "{foo) bar is the best thing ever"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E102'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E102"
         assert (
-            msgs[0].msg ==
-            'missing right curly-brace: {foo) bar is the best thing ever'
+            msgs[0].msg == "missing right curly-brace: {foo) bar is the best thing ever"
         )
 
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "{foo}"\n'
-            'msgstr "{foo"\n')
+            'msgstr "{foo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E102'
-        assert (
-            msgs[0].msg ==
-            'missing right curly-brace: {foo'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E102"
+        assert msgs[0].msg == "missing right curly-brace: {foo"
 
     def test_python_var_missing_right_curly_brace_two_vars(self):
         # Test right-most one
         linted_entry = build_linted_entry(
             'msgid "Value for key \\"{0}\\" exceeds the length of {1}"\n'
-            'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n')
+            'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E102'
-        assert (
-            msgs[0].msg ==
-            'missing right curly-brace: {1]'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E102"
+        assert msgs[0].msg == "missing right curly-brace: {1]"
 
         # Test left-most one
         linted_entry = build_linted_entry(
             'msgid "Value for key \\"{0}\\" exceeds the length of {1}"\n'
-            'msgstr "Valor para la clave \\"{0]\\" excede el tamano de {1}"\n')
+            'msgstr "Valor para la clave \\"{0]\\" excede el tamano de {1}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E102'
-        assert (
-            msgs[0].msg ==
-            'missing right curly-brace: {0]" excede el tamano de {'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E102"
+        assert msgs[0].msg == 'missing right curly-brace: {0]" excede el tamano de {'
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
 
         linted_entry = build_linted_entry(
             'msgid "Value for key \\"{0}\\" exceeds the length of {1}"\n'
-            'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n')
+            'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n'
+        )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
         assert msgs == []
@@ -327,54 +300,49 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
 
     def test_python_var_missing_left_curly_brace(self):
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "{product} Support Forum"\n'
-            'msgstr "product}-Hilfeforum"\n')
+            'msgstr "product}-Hilfeforum"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E103'
-        assert (
-            msgs[0].msg ==
-            'missing left curly-brace: product}'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E103"
+        assert msgs[0].msg == "missing left curly-brace: product}"
 
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/answers.html:56\n'
+            "#: kitsune/questions/templates/questions/answers.html:56\n"
             'msgid "{q} | {product} Support Forum"\n'
-            'msgstr "{q} | product}-Hilfeforum"\n')
+            'msgstr "{q} | product}-Hilfeforum"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E103'
-        assert (
-            msgs[0].msg ==
-            'missing left curly-brace: } | product}'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E103"
+        assert msgs[0].msg == "missing left curly-brace: } | product}"
 
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/question_details.html:14\n'
+            "#: kitsune/questions/templates/questions/question_details.html:14\n"
             'msgid "{q} | {product} Support Forum"\n'
-            'msgstr "{q} | {product}} foo bar"\n')
+            'msgstr "{q} | {product}} foo bar"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E103'
-        assert (
-            msgs[0].msg ==
-            'missing left curly-brace: }}'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E103"
+        assert msgs[0].msg == "missing left curly-brace: }}"
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
 
         linted_entry = build_linted_entry(
-            '#: kitsune/questions/templates/questions/question_details.html:14\n'
+            "#: kitsune/questions/templates/questions/question_details.html:14\n"
             'msgid "{q} | {product} Support Forum"\n'
-            'msgstr "{q} | {product}} foo bar"\n')
+            'msgstr "{q} | {product}} foo bar"\n'
+        )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
         assert msgs == []
@@ -385,64 +353,54 @@ class TestMissingVarsLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "Oof"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {foo}"\n'
-            'msgstr "Oof: {foo}"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
     def test_missing(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {foo}"\n'
-            'msgstr "Oof"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W202'
-        assert (
-            msgs[0].msg ==
-            'missing variables: {foo}'
-        )
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W202"
+        assert msgs[0].msg == "missing variables: {foo}"
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "Foo: {foo} {bar} {baz}"\n'
-            'msgstr "Oof: {foo}"\n')
+            'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W202'
-        assert (
-            msgs[0].msg ==
-            'missing variables: {bar}, {baz}'
-        )
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W202"
+        assert msgs[0].msg == "missing variables: {bar}, {baz}"
 
     def test_complex(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "Foo: {bar} {baz}"\n'
-            'msgstr "Oof: {foo} {bar}"\n')
+            'msgstr "Oof: {foo} {bar}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W202'
-        assert (
-            msgs[0].msg ==
-            'missing variables: {baz}'
-        )
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W202"
+        assert msgs[0].msg == "missing variables: {baz}"
 
     def test_plurals(self):
         # It's possible for the msgid to have no variables in it and
@@ -450,10 +408,11 @@ class TestMissingVarsLintRule(LintRuleTestCase):
         # should be compared against the set of variables in msgid and
         # msgid_plural. This tests the common case.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "1 reply"\n'
             'msgid_plural "{n} replies"\n'
-            'msgstr[0] "{n} mooo"\n')
+            'msgstr[0] "{n} mooo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
@@ -463,10 +422,11 @@ class TestMissingVarsLintRule(LintRuleTestCase):
         # msgid_plural, that's ok since we don't know which plurality
         # it is.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "1 post"\n'
             'msgid_plural "{0} posts"\n'
-            'msgstr[0] "1 moo"\n')
+            'msgstr[0] "1 moo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
@@ -475,9 +435,10 @@ class TestMissingVarsLintRule(LintRuleTestCase):
         # Double-percent shouldn't be picked up as a variable.
         # Issue #28.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "50% of the traffic"\n'
-            'msgstr "more than 50%% of the traffic"\n')
+            'msgstr "more than 50%% of the traffic"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
@@ -487,9 +448,10 @@ class TestMissingVarsLintRule(LintRuleTestCase):
         # as variables.
         # Issue #27.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "OMG! Best url is http://example.com/foo"\n'
-            'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n')
+            'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
@@ -498,24 +460,21 @@ class TestMissingVarsLintRule(LintRuleTestCase):
         # python-format unnamed variables must be in the msgstr so they're errors.
         # Issue #57
         linted_entry = build_linted_entry(
-            '#: kitsune/kbforums/feeds.py:23\n'
+            "#: kitsune/kbforums/feeds.py:23\n"
             'msgid "Recently updated threads about %s"\n'
             'msgstr "RECENTLY UPDATED THREADS"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E202'
-        assert (
-            msgs[0].msg ==
-            'missing variables: %s'
-        )
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E202"
+        assert msgs[0].msg == "missing variables: %s"
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
 
         linted_entry = build_linted_entry(
-            '#: kitsune/kbforums/feeds.py:23\n'
+            "#: kitsune/kbforums/feeds.py:23\n"
             'msgid "Recently updated threads about %s"\n'
             'msgstr "RECENTLY UPDATED THREADS"\n'
         )
@@ -528,55 +487,54 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "Oof"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {foo}"\n'
-            'msgstr "Oof: {foo}"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
     def test_invalid(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo {bar}"\n'
-            'msgstr "Oof: {foo}"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo {bar}"\n' 'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E201'
-        assert msgs[0].msg == 'invalid variables: {foo}'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E201"
+        assert msgs[0].msg == "invalid variables: {foo}"
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "Foo: {foo}"\n'
-            'msgstr "Oof: {foo} {bar} {baz}"\n')
+            'msgstr "Oof: {foo} {bar} {baz}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E201'
-        assert msgs[0].msg == 'invalid variables: {bar}, {baz}'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E201"
+        assert msgs[0].msg == "invalid variables: {bar}, {baz}"
 
     def test_complex(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "Foo: {bar} {baz}"\n'
-            'msgstr "Oof: {foo} {bar}"\n')
+            'msgstr "Oof: {foo} {bar}"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'err'
-        assert msgs[0].code == 'E201'
-        assert msgs[0].msg == 'invalid variables: {foo}'
+        assert msgs[0].kind == "err"
+        assert msgs[0].code == "E201"
+        assert msgs[0].msg == "invalid variables: {foo}"
 
     def test_plurals(self):
         # It's possible for the msgid to have no variables in it and
@@ -584,10 +542,11 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         # should be compared against the set of variables in msgid and
         # msgid_plural. This tests the common case.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "1 reply"\n'
             'msgid_plural "{n} replies"\n'
-            'msgstr[0] "{n} mooo"\n')
+            'msgstr[0] "{n} mooo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -596,9 +555,10 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         # Double-percent shouldn't be picked up as a variable.
         # Issue #28.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "50% of the traffic"\n'
-            'msgstr "more than 50%% of the traffic"\n')
+            'msgstr "more than 50%% of the traffic"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -608,18 +568,20 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         # as variables.
         # Issue #27.
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "OMG! Best url is http://example.com/foo"\n'
-            'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n')
+            'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
 
     def test_msgid_no_vars(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
+            "#: foo/foo.py:5\n"
             'msgid "http://en.wikipedia.org/wiki/Canvas_element"\n'
-            'msgstr "http://it.wikipedia.org/wiki/Canvas_%28elemento_HTML%29"\n')
+            'msgstr "http://it.wikipedia.org/wiki/Canvas_%28elemento_HTML%29"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert msgs == []
@@ -627,9 +589,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo {bar}"\n'
-            'msgstr "Oof: {foo}"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo {bar}"\n' 'msgstr "Oof: {foo}"\n'
+        )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
         assert msgs == []
@@ -640,30 +601,24 @@ class TestBlankLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr ""\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr ""\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
     def test_whitespace(self):
-        testdata = [
-            ' ',
-            '  ',
-            '\t'
-        ]
+        testdata = [" ", "  ", "\t"]
         for data in testdata:
             linted_entry = build_linted_entry(
-                '#: foo/foo.py:5\n'
-                'msgid "Foo"\n'
-                'msgstr "%s"\n' % data)
+                "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "%s"\n' % data
+            )
 
             msgs = self.lintrule.lint(self.vartok, linted_entry)
             assert len(msgs) == 1
-            assert msgs[0].kind == 'warn'
-            assert msgs[0].code == 'W301'
-            assert msgs[0].msg == 'translated string is solely whitespace'
+            assert msgs[0].kind == "warn"
+            assert msgs[0].code == "W301"
+            assert msgs[0].msg == "translated string is solely whitespace"
 
 
 class TestUnchangedLintRule(LintRuleTestCase):
@@ -671,15 +626,14 @@ class TestUnchangedLintRule(LintRuleTestCase):
 
     def test_unchanged(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo"\n'
-            'msgstr "Foo"\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Foo"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W302'
-        assert msgs[0].msg == 'translated string is same as source string'
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W302"
+        assert msgs[0].msg == "translated string is same as source string"
 
 
 class TestMismatchedHTMLLintRule(LintRuleTestCase):
@@ -687,58 +641,53 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
 
     def test_fine(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "<b>Foo</b>"\n'
-            'msgstr "<b>ARGH</b>"\n')
+            "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<b>ARGH</b>"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
     def test_fail(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "<b>Foo</b>"\n'
-            'msgstr "<em>ARGH</em>"\n')
+            "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<em>ARGH</em>"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W303'
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W303"
         assert msgs[0].msg == 'different html: "</b>" vs. "</em>"'
 
     def test_different_numbers(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "<b>Foo"\n'
-            'msgstr "<b>ARGH</b>"\n')
+            "#: foo/foo.py:5\n" 'msgid "<b>Foo"\n' 'msgstr "<b>ARGH</b>"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W303'
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W303"
         assert msgs[0].msg == 'different html: "<b>" vs. "</b>"'
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "<b>Foo</b>"\n'
-            'msgstr "<b>ARGH"\n')
+            "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<b>ARGH"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W303'
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W303"
         assert msgs[0].msg == 'different html: "</b>" vs. "<b>"'
 
     def test_invalid_html(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n' +
-            'msgid "<a>Foo</a>"\n' +
-            'msgstr "<a>ARGH</\u0430>"\n')
+            "#: foo/foo.py:5\n" + 'msgid "<a>Foo</a>"\n' + 'msgstr "<a>ARGH</\u0430>"\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
-        assert msgs[0].kind == 'warn'
-        assert msgs[0].code == 'W303'
+        assert msgs[0].kind == "warn"
+        assert msgs[0].code == "W303"
         # HTMLParser doesn't recognize </\u0430> as a valid HTML tag,
         # so you end up with:
         #
@@ -751,26 +700,24 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
 
 
 class TLRTestCase:
-    vartok = VariableTokenizer(['python-format', 'python-brace-format'])
+    vartok = VariableTokenizer(["python-format", "python-brace-format"])
 
 
 class TestHardToReadNamesTLR(TLRTestCase):
     lintrule = HardToReadNamesTLR()
 
     def test_hard_to_read_names(self):
-        for c in ('o', 'O', '0', 'l', '1'):
+        for c in ("o", "O", "0", "l", "1"):
             linted_entry = build_linted_entry(
-                '#: foo/foo.py:5\n'
-                'msgid "Foo: %(' + c + ')s"\n'
-                'msgstr ""\n')
+                "#: foo/foo.py:5\n" 'msgid "Foo: %(' + c + ')s"\n' 'msgstr ""\n'
+            )
 
             msgs = self.lintrule.lint(self.vartok, linted_entry)
             assert len(msgs) == 1
 
             linted_entry = build_linted_entry(
-                '#: foo/foo.py:5\n'
-                'msgid "Foo: {' + c + '}"\n'
-                'msgstr ""\n')
+                "#: foo/foo.py:5\n" 'msgid "Foo: {' + c + '}"\n' 'msgstr ""\n'
+            )
 
             msgs = self.lintrule.lint(self.vartok, linted_entry)
             assert len(msgs) == 1
@@ -782,17 +729,15 @@ class TestMultipleUnnamedVarsTLR(TLRTestCase):
 
     def test_multi_vars_no_name(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: %s %s"\n'
-            'msgstr ""\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: %s %s"\n' 'msgstr ""\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {} {}"\n'
-            'msgstr ""\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {} {}"\n' 'msgstr ""\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
@@ -804,17 +749,15 @@ class TestOneCharNamesTLR(TLRTestCase):
 
     def test_one_character_names(self):
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: %(c)s"\n'
-            'msgstr ""\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: %(c)s"\n' 'msgstr ""\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
 
         linted_entry = build_linted_entry(
-            '#: foo/foo.py:5\n'
-            'msgid "Foo: {c}"\n'
-            'msgstr ""\n')
+            "#: foo/foo.py:5\n" 'msgid "Foo: {c}"\n' 'msgstr ""\n'
+        )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,80 +4,89 @@ from dennis.tools import (
     VariableTokenizer,
     PythonFormat,
     PythonBraceFormat,
-    parse_dennis_note
+    parse_dennis_note,
 )
 
 
 def test_empty_tokenizer():
     vartok = VariableTokenizer([])
-    assert vartok.contains('python-format') is False
-    assert vartok.tokenize('a b c d e') == ['a b c d e']
-    assert vartok.extract_tokens('a b c d e') == set()
-    assert vartok.is_token('{0}') is False
-    assert vartok.extract_variable_name('{0}') is None
+    assert vartok.contains("python-format") is False
+    assert vartok.tokenize("a b c d e") == ["a b c d e"]
+    assert vartok.extract_tokens("a b c d e") == set()
+    assert vartok.is_token("{0}") is False
+    assert vartok.extract_variable_name("{0}") is None
 
 
-@pytest.mark.parametrize('text,expected', [
-    ('Hello %s', ['Hello ', '%s']),
-    ('Hello %(username)s', ['Hello ', '%(username)s']),
-    ('Hello %(user)s%(name)s', ['Hello ', '%(user)s', '%(name)s']),
-    ('Hello {username}', ['Hello ', '{username}']),
-    ('Hello {user}{name}', ['Hello ', '{user}', '{name}']),
-    ('Products and Services', ['Products and Services']),
-])
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Hello %s", ["Hello ", "%s"]),
+        ("Hello %(username)s", ["Hello ", "%(username)s"]),
+        ("Hello %(user)s%(name)s", ["Hello ", "%(user)s", "%(name)s"]),
+        ("Hello {username}", ["Hello ", "{username}"]),
+        ("Hello {user}{name}", ["Hello ", "{user}", "{name}"]),
+        ("Products and Services", ["Products and Services"]),
+    ],
+)
 def test_python_tokenizing(text, expected):
-    vartok = VariableTokenizer(['python-format', 'python-brace-format'])
+    vartok = VariableTokenizer(["python-format", "python-brace-format"])
     assert vartok.tokenize(text) == expected
 
 
-class TestPythonBraceFormat():
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', ['Hello']),
-        ('{foo}', ['{foo}']),
-        ('Hello {foo}', ['Hello ', '{foo}']),
-        ('{foo} Hello', ['{foo}', ' Hello']),
-        ('{foo:%Y-%m-%d}', ['{foo:%Y-%m-%d}']),
-        ('{foo:%Y-%m-%d %H:%M}', ['{foo:%Y-%m-%d %H:%M}'])
-    ])
+class TestPythonBraceFormat:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", ["Hello"]),
+            ("{foo}", ["{foo}"]),
+            ("Hello {foo}", ["Hello ", "{foo}"]),
+            ("{foo} Hello", ["{foo}", " Hello"]),
+            ("{foo:%Y-%m-%d}", ["{foo:%Y-%m-%d}"]),
+            ("{foo:%Y-%m-%d %H:%M}", ["{foo:%Y-%m-%d %H:%M}"]),
+        ],
+    )
     def test_parse(self, text, expected):
-        vartok = VariableTokenizer(['python-brace-format'])
+        vartok = VariableTokenizer(["python-brace-format"])
         assert vartok.tokenize(text) == expected
 
-    @pytest.mark.parametrize('text,expected', [
-        ('{}', ''),
-        ('{0}', '0'),
-        ('{abc}', 'abc'),
-        ('{abc.def}', 'abc.def'),
-        ('{abc[0]}', 'abc[0]'),
-        ('{abc!s}', 'abc'),  # conversion
-        ('{abc: >16}', 'abc'),  # format_spec
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("{}", ""),
+            ("{0}", "0"),
+            ("{abc}", "abc"),
+            ("{abc.def}", "abc.def"),
+            ("{abc[0]}", "abc[0]"),
+            ("{abc!s}", "abc"),  # conversion
+            ("{abc: >16}", "abc"),  # format_spec
+        ],
+    )
     def test_variable_name(self, text, expected):
         v = PythonBraceFormat()
         assert v.extract_variable_name(text) == expected
 
 
-@pytest.mark.parametrize('text,expected', [
-    ('%s', ''),
-    ('%d', ''),
-    ('%.2f', ''),
-    ('%(foo)s', 'foo'),
-])
+@pytest.mark.parametrize(
+    "text,expected", [("%s", ""), ("%d", ""), ("%.2f", ""), ("%(foo)s", "foo")]
+)
 def test_pythonformat(text, expected):
     v = PythonFormat()
     assert v.extract_variable_name(text) == expected
 
 
-@pytest.mark.parametrize('text,expected', [
-    ('', []),
-    ('Foo', []),
-    ('Foo bar', []),
-    ('dennis-ignore', []),
-    ('dennis-ignore: *', '*'),
-    ('dennis-ignore: E101', ['E101']),
-    ('dennis-ignore: E101, E102', ['E101']),
-    ('dennis-ignore: E101,E102', ['E101', 'E102']),
-    ('localizers ignore this: dennis-ignore: E101,E102', ['E101', 'E102']),
-])
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("", []),
+        ("Foo", []),
+        ("Foo bar", []),
+        ("dennis-ignore", []),
+        ("dennis-ignore: *", "*"),
+        ("dennis-ignore: E101", ["E101"]),
+        ("dennis-ignore: E101, E102", ["E101"]),
+        ("dennis-ignore: E101,E102", ["E101", "E102"]),
+        ("localizers ignore this: dennis-ignore: E101,E102", ["E101", "E102"]),
+    ],
+)
 def test_parse_dennis_note(text, expected):
     assert parse_dennis_note(text) == expected

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -15,349 +15,317 @@ from dennis.translator import (
     Translator,
     DoubleTransform,
     XXXTransform,
-    ZombieTransform
+    ZombieTransform,
 )
 
 
 class TransformTestCase:
-    vartok = VariableTokenizer(['python-format', 'python-brace-format'])
+    vartok = VariableTokenizer(["python-format", "python-brace-format"])
 
 
 class TestEmptyTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', ''),
-        ('OMG!', ''),
-        ('', ''),
-    ])
+    @pytest.mark.parametrize("text,expected", [("Hello", ""), ("OMG!", ""), ("", "")])
     def test_basic(self, text, expected):
         trans = EmptyTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestHahaTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'Haha\u2757 Hello'),
-        ('OMG! Hello!', 'Haha\u2757 OMG! Haha\u2757 Hello!'),
-        ('', 'Haha\u2757 '),
-        ('Hi!\nHello!', 'Haha\u2757 Hi!\nHaha\u2757 Hello!'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "Haha\u2757 Hello"),
+            ("OMG! Hello!", "Haha\u2757 OMG! Haha\u2757 Hello!"),
+            ("", "Haha\u2757 "),
+            ("Hi!\nHello!", "Haha\u2757 Hi!\nHaha\u2757 Hello!"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = HahaTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestPirateTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello',
-         '\'ello ahoy\u2757'),
-
-        ('Hello %(username)s',
-         '\'ello %(username)s ahoy\u2757'),
-
-        ('Hello %s',
-         '\'ello %s cap\'n\u2757'),
-
-        ('Hello {user}{name}',
-         '\'ello {user}{name} ahoy\u2757'),
-
-        ('Products and Services',
-         'Products and Sarrvices yo-ho-ho\u2757'),
-
-        ('Get community support',
-         'Get community supparrt yo-ho-ho\u2757'),
-
-        ('Your input helps make Mozilla better',
-         'Yerr input \'elps make Mozillar betterr prepare to be boarded\u2757'),
-
-        ('Super browsing',
-         'Superr browsin\' arrRRRrrr\u2757'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "'ello ahoy\u2757"),
+            ("Hello %(username)s", "'ello %(username)s ahoy\u2757"),
+            ("Hello %s", "'ello %s cap'n\u2757"),
+            ("Hello {user}{name}", "'ello {user}{name} ahoy\u2757"),
+            ("Products and Services", "Products and Sarrvices yo-ho-ho\u2757"),
+            ("Get community support", "Get community supparrt yo-ho-ho\u2757"),
+            (
+                "Your input helps make Mozilla better",
+                "Yerr input 'elps make Mozillar betterr prepare to be boarded\u2757",
+            ),
+            ("Super browsing", "Superr browsin' arrRRRrrr\u2757"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = PirateTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestDubstepTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello',
-         'Hello t-t-t-t\u2757'),
-
-        ('Hello %(username)s',
-         'Hello t-t-t-t %(username)s BWWWWWWAAAAAAAAaaaaaa\u2757'),
-
-        ('Hello %s',
-         'Hello t-t-t-t %s BWWWWAAAAAaaaa\u2757'),
-
-        ('Hello {user}{name}',
-         'Hello t-t-t-t {user}{name} BWWWWWWAAAAAAAAaaaaaa\u2757'),
-
-        ('Products and Services',
-         'Products and Services BWWWWWAAAAAAAaaaaa\u2757'),
-
-        ('Get community support',
-         ('Get t-t-t-t community BWWWWWAAAAAAAaaaaa support V\u221eP V\u221eP\u2757')),
-
-        ('Your input helps make Mozilla better',
-         ('Your input helps make BWWWWWAAAAAAAaaaaa Mozilla '
-          '....vvvVV better BWWWWWWAAAAAAAAaaaaaa\u2757')),
-
-        ('Super browsing',
-         'Super t-t-t-t browsing BWWWWWAAAAAAAaaaaa\u2757'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "Hello t-t-t-t\u2757"),
+            (
+                "Hello %(username)s",
+                "Hello t-t-t-t %(username)s BWWWWWWAAAAAAAAaaaaaa\u2757",
+            ),
+            ("Hello %s", "Hello t-t-t-t %s BWWWWAAAAAaaaa\u2757"),
+            (
+                "Hello {user}{name}",
+                "Hello t-t-t-t {user}{name} BWWWWWWAAAAAAAAaaaaaa\u2757",
+            ),
+            ("Products and Services", "Products and Services BWWWWWAAAAAAAaaaaa\u2757"),
+            (
+                "Get community support",
+                (
+                    "Get t-t-t-t community BWWWWWAAAAAAAaaaaa support V\u221eP V\u221eP\u2757"
+                ),
+            ),
+            (
+                "Your input helps make Mozilla better",
+                (
+                    "Your input helps make BWWWWWAAAAAAAaaaaa Mozilla "
+                    "....vvvVV better BWWWWWWAAAAAAAAaaaaaa\u2757"
+                ),
+            ),
+            ("Super browsing", "Super t-t-t-t browsing BWWWWWAAAAAAAaaaaa\u2757"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = DubstepTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestZombieTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('', ''),
-        ('Hello', 'HHAMNMNHR RARRR!!!'),
-        ('Hi\nHello', 'HAR\nHHAMNMNHR BR-R-R-RAINS!'),
-        ('Hi   \nHello!\nmultiline',
-         'HAR   \nHHAMNMNHR\u2757\nmNMMNHGARMNARnHA'),
-        ('Hello %(username)s', 'HHAMNMNHR %(username)s'),
-        ('Hello %s', 'HHAMNMNHR %s GRRRRRrrRR!!'),
-        # FIXME: This is a problem where variables from the variable tokenizer should
-        # be treated as immutable tokens and right now they aren't. Issue #67.
-        ('Hello {user}{name}', 'HHAMNMNHR {user}{namHA}'),
-        ('Products and Services',
-         'PMZHRGBNMZZHGRZ anGB SHAMZBBARZZHARZ'),
-        ('Get community support',
-         'GHAHG ZZHRmmNMnARHGRA RZNMBZBZHRMZHG'),
-        ('Your input helps make Mozilla better',
-         ('YHRNMMZ ARnBZNMHG hHAMNBZRZ maBGHA MHRzARMNMNa bHAHGHGHAMZ '
-          'BR-R-R-RAINS!')),
-        ('Super browsing', 'SNMBZHAMZ bMZHRZMRZARng'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("", ""),
+            ("Hello", "HHAMNMNHR RARRR!!!"),
+            ("Hi\nHello", "HAR\nHHAMNMNHR BR-R-R-RAINS!"),
+            ("Hi   \nHello!\nmultiline", "HAR   \nHHAMNMNHR\u2757\nmNMMNHGARMNARnHA"),
+            ("Hello %(username)s", "HHAMNMNHR %(username)s"),
+            ("Hello %s", "HHAMNMNHR %s GRRRRRrrRR!!"),
+            # FIXME: This is a problem where variables from the variable tokenizer should
+            # be treated as immutable tokens and right now they aren't. Issue #67.
+            ("Hello {user}{name}", "HHAMNMNHR {user}{namHA}"),
+            ("Products and Services", "PMZHRGBNMZZHGRZ anGB SHAMZBBARZZHARZ"),
+            ("Get community support", "GHAHG ZZHRmmNMnARHGRA RZNMBZBZHRMZHG"),
+            (
+                "Your input helps make Mozilla better",
+                (
+                    "YHRNMMZ ARnBZNMHG hHAMNBZRZ maBGHA MHRzARMNMNa bHAHGHGHAMZ "
+                    "BR-R-R-RAINS!"
+                ),
+            ),
+            ("Super browsing", "SNMBZHAMZ bMZHRZMRZARng"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = ZombieTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestHTMLExtractor:
-    vartok = VariableTokenizer(['python-format', 'python-brace-format'])
+    vartok = VariableTokenizer(["python-format", "python-brace-format"])
 
     def test_basic(self):
         trans = HTMLExtractorTransform()
-        output = trans.transform(self.vartok, [Token('')])
-        assert output == [Token('', 'text', True)]
+        output = trans.transform(self.vartok, [Token("")])
+        assert output == [Token("", "text", True)]
 
-        output = trans.transform(self.vartok, [Token('<b>hi</b>')])
-        assert (
-            output ==
-            [
-                Token('<b>', 'html', False),
-                Token('hi', 'text', True),
-                Token('</b>', 'html', False),
-            ]
-        )
+        output = trans.transform(self.vartok, [Token("<b>hi</b>")])
+        assert output == [
+            Token("<b>", "html", False),
+            Token("hi", "text", True),
+            Token("</b>", "html", False),
+        ]
 
     def test_alt_title_placeholder(self):
         trans = HTMLExtractorTransform()
-        output = trans.transform(self.vartok, [
-            Token('<img alt="foo">')])
-        assert (
-            output ==
-            [
-                Token('<img alt="', 'html', False),
-                Token('foo', 'text', True),
-                Token('">', 'html', False),
-            ]
-        )
+        output = trans.transform(self.vartok, [Token('<img alt="foo">')])
+        assert output == [
+            Token('<img alt="', "html", False),
+            Token("foo", "text", True),
+            Token('">', "html", False),
+        ]
 
-        output = trans.transform(self.vartok, [
-            Token('<img title="foo">')])
-        assert (
-            output ==
-            [
-                Token('<img title="', 'html', False),
-                Token('foo', 'text', True),
-                Token('">', 'html', False),
-            ]
-        )
+        output = trans.transform(self.vartok, [Token('<img title="foo">')])
+        assert output == [
+            Token('<img title="', "html", False),
+            Token("foo", "text", True),
+            Token('">', "html", False),
+        ]
 
-        output = trans.transform(self.vartok, [
-            Token('<input placeholder="foo">')])
-        assert (
-            output ==
-            [
-                Token('<input placeholder="', 'html', False),
-                Token('foo', 'text', True),
-                Token('">', 'html', False),
-            ]
-        )
+        output = trans.transform(self.vartok, [Token('<input placeholder="foo">')])
+        assert output == [
+            Token('<input placeholder="', "html", False),
+            Token("foo", "text", True),
+            Token('">', "html", False),
+        ]
 
     def test_script_style(self):
         trans = HTMLExtractorTransform()
-        output = trans.transform(self.vartok, [
-            Token('<style>TR {white-space: nowrap;}</style>')
-        ])
-        assert (
-            output ==
-            [
-                Token('<style>', 'html', False),
-                Token('TR {white-space: nowrap;}', 'style', False),
-                Token('</style>', 'html', False)
-            ]
+        output = trans.transform(
+            self.vartok, [Token("<style>TR {white-space: nowrap;}</style>")]
         )
+        assert output == [
+            Token("<style>", "html", False),
+            Token("TR {white-space: nowrap;}", "style", False),
+            Token("</style>", "html", False),
+        ]
 
-        output = trans.transform(self.vartok, [
-            Token('<script>console.log("foo");</script>')
-        ])
-        assert (
-            output ==
-            [
-                Token('<script>', 'html', False),
-                Token('console.log("foo");', 'script', False),
-                Token('</script>', 'html', False)
-            ]
+        output = trans.transform(
+            self.vartok, [Token('<script>console.log("foo");</script>')]
         )
+        assert output == [
+            Token("<script>", "html", False),
+            Token('console.log("foo");', "script", False),
+            Token("</script>", "html", False),
+        ]
 
     def test_whitespace_collapse(self):
         def _trans(text):
             return HTMLExtractorTransform().transform(self.vartok, [Token(text)])
 
-        assert (
-            _trans('<html><body>hello!</body></html>') ==
-            _trans('<html><body>    hello!    </body></html>')
+        assert _trans("<html><body>hello!</body></html>") == _trans(
+            "<html><body>    hello!    </body></html>"
         )
 
 
 class TestXXXTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'xxxHelloxxx'),
-        ('OMG!', 'xxxOMG!xxx'),
-        ('Line\nWith\nCRs', 'xxxLinexxx\nxxxWithxxx\nxxxCRsxxx'),
-        ('Line.  \nWith!\nCRs', 'xxxLine.xxx  \nxxxWith!xxx\nxxxCRsxxx')
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "xxxHelloxxx"),
+            ("OMG!", "xxxOMG!xxx"),
+            ("Line\nWith\nCRs", "xxxLinexxx\nxxxWithxxx\nxxxCRsxxx"),
+            ("Line.  \nWith!\nCRs", "xxxLine.xxx  \nxxxWith!xxx\nxxxCRsxxx"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = XXXTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestDoubleTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'Heelloo'),
-        ('OMG!', 'OOMG!'),
-        ('Line\nWith\nCRs', 'Liinee\nWiith\nCRs'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "Heelloo"),
+            ("OMG!", "OOMG!"),
+            ("Line\nWith\nCRs", "Liinee\nWiith\nCRs"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = DoubleTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestAngleQuoteTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', '\xabHello\xbb'),
-        ('OMG!', '\xabOMG!\xbb'),
-        ('Line\nWith\nCRs', '\xabLine\nWith\nCRs\xbb'),
-        ('Line.  \nWith!\nCRs', '\xabLine.  \nWith!\nCRs\xbb'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "\xabHello\xbb"),
+            ("OMG!", "\xabOMG!\xbb"),
+            ("Line\nWith\nCRs", "\xabLine\nWith\nCRs\xbb"),
+            ("Line.  \nWith!\nCRs", "\xabLine.  \nWith!\nCRs\xbb"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = AngleQuoteTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestShoutyTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'HELLO'),
-        ('OMG!', 'OMG!'),
-        ('<b>Hello.</b>', '<B>HELLO.</B>'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [("Hello", "HELLO"), ("OMG!", "OMG!"), ("<b>Hello.</b>", "<B>HELLO.</B>")],
+    )
     def test_basic(self, text, expected):
         trans = ShoutyTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestReverseTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'olleH'),
-        ('OMG!', '!GMO'),
-        ('Hello. This is a test.', '.tset a si sihT .olleH'),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Hello", "olleH"),
+            ("OMG!", "!GMO"),
+            ("Hello. This is a test.", ".tset a si sihT .olleH"),
+        ],
+    )
     def test_basic(self, text, expected):
         trans = ReverseTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestRedactedTransform(TransformTestCase):
-    @pytest.mark.parametrize('text,expected', [
-        ('Hello', 'Xxxxx'),
-        ('OMG!', 'XXX!'),
-    ])
+    @pytest.mark.parametrize("text,expected", [("Hello", "Xxxxx"), ("OMG!", "XXX!")])
     def test_basic(self, text, expected):
         trans = RedactedTransform()
         output = trans.transform(self.vartok, [Token(text)])
-        output = ''.join([token.s for token in output])
+        output = "".join([token.s for token in output])
 
         assert output == expected
 
 
 class TestTranslator:
     def test_pirate_translate(self):
-        trans = Translator(
-            ['python-format', 'python-brace-format'],
-            ['pirate']
-        )
-        assert (
-            trans.translate_string('hello') ==
-            '\'ello ahoy\u2757'
-        )
+        trans = Translator(["python-format", "python-brace-format"], ["pirate"])
+        assert trans.translate_string("hello") == "'ello ahoy\u2757"
 
         # Note, this doesn't work right because it's not accounting
         # for html. But it's correct for this test.
         assert (
-            trans.translate_string('<b>hello</b>') ==
-            '<b>\'ello</b> prepare to be boarded\u2757'
+            trans.translate_string("<b>hello</b>")
+            == "<b>'ello</b> prepare to be boarded\u2757"
         )
 
     def test_html_pirate_translate(self):
-        trans = Translator(
-            ['python-format', 'python-brace-format'],
-            ['html', 'pirate']
-        )
-        assert (
-            trans.translate_string('<b>hello</b>') ==
-            '<b>\'ello ahoy\u2757</b>'
-        )
+        trans = Translator(["python-format", "python-brace-format"], ["html", "pirate"])
+        assert trans.translate_string("<b>hello</b>") == "<b>'ello ahoy\u2757</b>"
 
     def test_shouty_html_pirate_translate(self):
         trans = Translator(
-            ['python-format', 'python-brace-format'],
-            ['shouty', 'html', 'pirate']
+            ["python-format", "python-brace-format"], ["shouty", "html", "pirate"]
         )
-        assert (
-            trans.translate_string('<b>hello.</b>\n') ==
-            '<b>HELLO aye\u2757.</b>'
-        )
+        assert trans.translate_string("<b>hello.</b>\n") == "<b>HELLO aye\u2757.</b>"

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,py36-lint
 
 [testenv]
 commands = pip install -r requirements-dev.txt
            pytest
+
+
+[testenv:py36-lint]
+basepython = python3.6
+commands = pip install -r requirements-dev.txt
+           black --check --target-version=py35 dennis tests
+           flake8 dennis tests


### PR DESCRIPTION
This reformats the code using black and lints it with flake8. It also adds bits to CI to the tox configuration so that we do that in CI.

It also adds `lint` and `clean` rules to a `Makefile`.

Fixes #113 