### PR TITLE
fix(packaging): exclude tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     keywords="l10n localization gettext PO POT lint translate development",
     url="https://github.com/mozilla/dennis",
     zip_safe=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=INSTALL_REQUIRES,
     entry_points="""


### PR DESCRIPTION
## Problem

Currently, the `tests` directory is included in the final package distribution (wheel). This happens because `setup.py` uses `find_packages()` without an `exclude` argument, and the `tests/` directory contains an `__init__.py` file, which causes it to be discovered as a package.

This creates a serious namespace collision for any downstream project that also has a local `tests` directory. The Python import system and language servers (like Pylance) will find the `tests` directory from `dennis` located in `site-packages` before finding the project's own local `tests` directory. 

## Solution

This PR resolves the issue by explicitly excluding the `tests` directory during package discovery in `setup.py`.

The change is as follows:

```diff
- packages=find_packages(),
+ packages=find_packages(exclude=['tests']),
