### PR TITLE
Fix W303 false positive for unclosed CDATA/RCDATA tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
 
     strategy:
       matrix:

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -403,8 +403,6 @@ class MismatchedHTMLLintRule(LintRule):
 
         from dennis.translator import HTMLExtractorTransform, Token
 
-        html = HTMLExtractorTransform()
-
         def equiv(left, right):
             return left == right
 
@@ -414,6 +412,8 @@ class MismatchedHTMLLintRule(LintRule):
             :raises HTMLParseError: If it's invalid HTML.
 
             """
+            html = HTMLExtractorTransform()
+
             tokens = [
                 token
                 for token in html.transform(vartok, [Token(text)])

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,4 +1,5 @@
 import polib
+import pytest
 
 from dennis.linter import (
     BadFormatLintRule,
@@ -706,6 +707,46 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
         #
         # [<html <a>>]
         assert msgs[0].msg == 'different html: "</a>" vs. "<a>"'
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "title",
+            "script",
+            "style",
+            "textarea",
+            "br",
+            "hr",
+            "img",
+            "input",
+            "link",
+            "meta",
+            "span",
+            "a",
+            "b",
+            "i",
+            "button",
+            "p",
+            "div",
+            "table",
+            "form",
+            "header",
+            "footer",
+            "canvas",
+            "noscript",
+            "description",
+            "html",
+            "head",
+            "body",
+        ],
+    )
+    def test_tag(self, tag):
+        linted_entry = build_linted_entry(
+            "#: foo/foo.py:5\n" 'msgid "tag: <{tag}>"\n' 'msgstr "TAG: <{tag}>"\n'.format(tag=tag)
+        )
+
+        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        assert len(msgs) == 0
 
 
 class TLRTestCase:

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -711,33 +711,18 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
     @pytest.mark.parametrize(
         "tag",
         [
+            # CDATA/RCDATA elements
             "title",
             "script",
             "style",
             "textarea",
+            "iframe",
+            # Void elements
             "br",
-            "hr",
             "img",
-            "input",
-            "link",
-            "meta",
-            "span",
+            # Normal elements
             "a",
-            "b",
-            "i",
-            "button",
-            "p",
             "div",
-            "table",
-            "form",
-            "header",
-            "footer",
-            "canvas",
-            "noscript",
-            "description",
-            "html",
-            "head",
-            "body",
         ],
     )
     def test_tag(self, tag):


### PR DESCRIPTION
Thanks for maintaining Dennis!
Fixes #213.

## Cause
`MismatchedHTMLLintRule.lint` currently reuses a single `HTMLExtractorTransform` instance to tokenize both `msgid` and `msgstr`.

Since `HTMLExtractorTransform` inherits from `html.parser.HTMLParser`, it maintains internal state:

https://github.com/mozilla/dennis/blob/3e2608a2ac1f509ea7fdc8dc9ba758aaa9c00749/dennis/translator.py#L585-L587

When `HTMLParser` encounters [certain tags like `<title>`, `<script>`, `<style>`, `<textarea>`, or `<iframe>`](https://github.com/python/cpython/blob/23116f998f6789d8c2fbe5ed5b8146854c8c2a4f/Lib/html/parser.py#L131-L135),
[it enters a CDATA/RCDATA parsing mode](https://github.com/python/cpython/blob/23116f998f6789d8c2fbe5ed5b8146854c8c2a4f/Lib/html/parser.py#L466-L471), where it treats all subsequent data
as character data rather than HTML markup until the matching closing tag is found.


If any of these tags are left unclosed in the `msgid`, the parser remains in this special mode.
This state then leaks into the parsing of `msgstr`, causing any HTML tags in the `msgstr` to be misidentified
as character data, which triggers the false positive.

## Changes
Moved the instantiation of `HTMLExtractorTransform` inside the `tokenize` function.
This ensures that a fresh parser instance is used for each string, preventing any state leakage.

🔴 Red → 🟢 Green cycle:
1. 1116c39: Add test cases for various HTML tags – 🔴 **RED** at this point due to the existing bug ([job log](https://github.com/skkzsh/dennis/actions/runs/25310782410/job/74196896573#step:6:506)).
2. fee57f9: Move `HTMLExtractorTransform` instantiation inside the function to resolve the state leakage – 🟢 **GREEN**  ([job log](https://github.com/skkzsh/dennis/actions/runs/25310885859/job/74197236624#step:6:304)).
