### PR TITLE
perf: Eliminate uuid4() calls

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -106,7 +106,7 @@ class MalformedNoTypeLintRule(LintRule):
     name = "notype"
     desc = "%(count) with no type at the end"
 
-    MALFORMED_RE = re.compile(
+    _MALFORMED_RE = re.compile(
         r"(?:"
         r"%"  # %
         r"[\(][^\)\s]+[\)]"  # things in parens or not
@@ -125,7 +125,7 @@ class MalformedNoTypeLintRule(LintRule):
             if not trstr.msgstr_string:
                 continue
 
-            malformed = self.MALFORMED_RE.findall(trstr.msgstr_string)
+            malformed = self._MALFORMED_RE.findall(trstr.msgstr_string)
             if not malformed:
                 continue
 
@@ -149,9 +149,9 @@ class MalformedMissingRightBraceLintRule(LintRule):
     name = "missingrightbrace"
     desc = "{foo with missing }"
 
-    MALFORMED_RE = re.compile(r"(?:\{[^\}]+(?:\{|$))")
-    DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
-    DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
+    _MALFORMED_RE = re.compile(r"(?:\{[^\}]+(?:\{|$))")
+    _DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
+    _DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -164,16 +164,16 @@ class MalformedMissingRightBraceLintRule(LintRule):
             if not trstr.msgstr_string:
                 continue
 
-            malformed = self.MALFORMED_RE.findall(
-                trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
-                    "}}", self.DOUBLE_CLOSE
+            malformed = self._MALFORMED_RE.findall(
+                trstr.msgstr_string.replace("{{", self._DOUBLE_OPEN).replace(
+                    "}}", self._DOUBLE_CLOSE
                 )
             )
             if not malformed:
                 continue
 
             malformed = [
-                item.strip().replace(self.DOUBLE_OPEN, "{{").replace(self.DOUBLE_CLOSE, "}}")
+                item.strip().replace(self._DOUBLE_OPEN, "{{").replace(self._DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
             msgs.append(
@@ -195,9 +195,9 @@ class MalformedMissingLeftBraceLintRule(LintRule):
     name = "missingleftbrace"
     desc = "foo} with missing {"
 
-    MALFORMED_RE = re.compile(r"(?:(?:^|\})[^\{]*\})")
-    DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
-    DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
+    _MALFORMED_RE = re.compile(r"(?:(?:^|\})[^\{]*\})")
+    _DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
+    _DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -210,16 +210,16 @@ class MalformedMissingLeftBraceLintRule(LintRule):
             if not trstr.msgstr_string:
                 continue
 
-            malformed = self.MALFORMED_RE.findall(
-                trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
-                    "}}", self.DOUBLE_CLOSE
+            malformed = self._MALFORMED_RE.findall(
+                trstr.msgstr_string.replace("{{", self._DOUBLE_OPEN).replace(
+                    "}}", self._DOUBLE_CLOSE
                 )
             )
             if not malformed:
                 continue
 
             malformed = [
-                item.strip().replace(self.DOUBLE_OPEN, "{{").replace(self.DOUBLE_CLOSE, "}}")
+                item.strip().replace(self._DOUBLE_OPEN, "{{").replace(self._DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
             msgs.append(
@@ -240,7 +240,7 @@ class BadFormatLintRule(LintRule):
     name = "badformat"
     desc = "% followed by a bad format character"
 
-    SPLITTER = re.compile(r"(\%(?:.|$))")
+    _SPLITTER = re.compile(r"(\%(?:.|$))")
 
     def lint(self, vartok, linted_entry):
         msgs = []
@@ -262,7 +262,7 @@ class BadFormatLintRule(LintRule):
             if not (len(first_token) == 2 and first_token[0] == "%"):
                 continue
 
-            for match in self.SPLITTER.findall(trstr.msgstr_string):
+            for match in self._SPLITTER.findall(trstr.msgstr_string):
                 if len(match) == 1 or match[1] not in "(diouxefGgcrs%":
                     msgs.append(
                         LintMessage(

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -106,6 +106,14 @@ class MalformedNoTypeLintRule(LintRule):
     name = "notype"
     desc = "%(count) with no type at the end"
 
+    MALFORMED_RE = re.compile(
+        r"(?:"
+        r"%"  # %
+        r"[\(][^\)\s]+[\)]"  # things in parens or not
+        r"(?:(?=[^diouxefGgcrs])|$)"  # end of string or something that's not a format char
+        r")"
+    )
+
     def lint(self, vartok, linted_entry):
         msgs = []
 
@@ -113,19 +121,11 @@ class MalformedNoTypeLintRule(LintRule):
         if not vartok.contains("python-format"):
             return msgs
 
-        malformed_re = re.compile(
-            r"(?:"
-            r"%"  # %
-            r"[\(][^\)\s]+[\)]"  # things in parens or not
-            r"(?:(?=[^diouxefGgcrs])|$)"  # end of string or something that's not a format char
-            r")"
-        )
-
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
-            malformed = malformed_re.findall(trstr.msgstr_string)
+            malformed = self.MALFORMED_RE.findall(trstr.msgstr_string)
             if not malformed:
                 continue
 
@@ -149,6 +149,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
     name = "missingrightbrace"
     desc = "{foo with missing }"
 
+    MALFORMED_RE = re.compile(r"(?:\{[^\}]+(?:\{|$))")
     DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
     DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
@@ -159,13 +160,11 @@ class MalformedMissingRightBraceLintRule(LintRule):
         if not vartok.contains("python-brace-format"):
             return []
 
-        malformed_re = re.compile(r"(?:\{[^\}]+(?:\{|$))")
-
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
-            malformed = malformed_re.findall(
+            malformed = self.MALFORMED_RE.findall(
                 trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
                     "}}", self.DOUBLE_CLOSE
                 )
@@ -196,6 +195,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
     name = "missingleftbrace"
     desc = "foo} with missing {"
 
+    MALFORMED_RE = re.compile(r"(?:(?:^|\})[^\{]*\})")
     DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
     DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
@@ -206,13 +206,11 @@ class MalformedMissingLeftBraceLintRule(LintRule):
         if not vartok.contains("python-brace-format"):
             return []
 
-        malformed_re = re.compile(r"(?:(?:^|\})[^\{]*\})")
-
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
-            malformed = malformed_re.findall(
+            malformed = self.MALFORMED_RE.findall(
                 trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
                     "}}", self.DOUBLE_CLOSE
                 )
@@ -242,14 +240,14 @@ class BadFormatLintRule(LintRule):
     name = "badformat"
     desc = "% followed by a bad format character"
 
+    SPLITTER = re.compile(r"(\%(?:.|$))")
+
     def lint(self, vartok, linted_entry):
         msgs = []
 
         # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains("python-format"):
             return []
-
-        splitter = re.compile(r"(\%(?:.|$))")
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
@@ -264,7 +262,7 @@ class BadFormatLintRule(LintRule):
             if not (len(first_token) == 2 and first_token[0] == "%"):
                 continue
 
-            for match in splitter.findall(trstr.msgstr_string):
+            for match in self.SPLITTER.findall(trstr.msgstr_string):
                 if len(match) == 1 or match[1] not in "(diouxefGgcrs%":
                     msgs.append(
                         LintMessage(

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 from collections import namedtuple
 from itertools import zip_longest
 
@@ -150,6 +149,9 @@ class MalformedMissingRightBraceLintRule(LintRule):
     name = "missingrightbrace"
     desc = "{foo with missing }"
 
+    DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
+    DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
+
     def lint(self, vartok, linted_entry):
         msgs = []
 
@@ -158,23 +160,21 @@ class MalformedMissingRightBraceLintRule(LintRule):
             return []
 
         malformed_re = re.compile(r"(?:\{[^\}]+(?:\{|$))")
-        double_open = str(uuid.uuid4())
-        double_close = str(uuid.uuid4())
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
             malformed = malformed_re.findall(
-                trstr.msgstr_string.replace("{{", double_open).replace(
-                    "}}", double_close
+                trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
+                    "}}", self.DOUBLE_CLOSE
                 )
             )
             if not malformed:
                 continue
 
             malformed = [
-                item.strip().replace(double_open, "{{").replace(double_close, "}}")
+                item.strip().replace(self.DOUBLE_OPEN, "{{").replace(self.DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
             msgs.append(
@@ -196,6 +196,9 @@ class MalformedMissingLeftBraceLintRule(LintRule):
     name = "missingleftbrace"
     desc = "foo} with missing {"
 
+    DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
+    DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
+
     def lint(self, vartok, linted_entry):
         msgs = []
 
@@ -204,23 +207,21 @@ class MalformedMissingLeftBraceLintRule(LintRule):
             return []
 
         malformed_re = re.compile(r"(?:(?:^|\})[^\{]*\})")
-        double_open = str(uuid.uuid4())
-        double_close = str(uuid.uuid4())
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
             malformed = malformed_re.findall(
-                trstr.msgstr_string.replace("{{", double_open).replace(
-                    "}}", double_close
+                trstr.msgstr_string.replace("{{", self.DOUBLE_OPEN).replace(
+                    "}}", self.DOUBLE_CLOSE
                 )
             )
             if not malformed:
                 continue
 
             malformed = [
-                item.strip().replace(double_open, "{{").replace(double_close, "}}")
+                item.strip().replace(self.DOUBLE_OPEN, "{{").replace(self.DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
             msgs.append(

--- a/dennis/tools.py
+++ b/dennis/tools.py
@@ -150,7 +150,7 @@ class VariableTokenizer:
 
     def extract_variable_name(self, text):
         for fmt in self.formats:
-            if re.compile(fmt.regexp).match(text):
+            if re.match(fmt.regexp, text):
                 return fmt.extract_variable_name(text)
 
 


### PR DESCRIPTION
Thanks for maintaining Dennis!
Fixes #216.

This yields a 25%+ reduction in lint execution time (benchmarked with 10k entries). Profile details:

```console
dennis version 1.2.0
         2121698 function calls (2120420 primitive calls) in 0.510 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.039    0.000    0.352    0.000 linter.py:572(lint_poentry)
    90000    0.034    0.000    0.063    0.000 linter.py:59(strs)
        1    0.024    0.024    0.119    0.119 polib.py:1328(parse)
    20000    0.022    0.000    0.089    0.000 parser.py:214(goahead)
    20000    0.018    0.000    0.148    0.000 linter.py:409(tokenize)
    60050    0.017    0.000    0.032    0.000 __init__.py:330(_compile)
    90000    0.013    0.000    0.022    0.000 <string>:1(<lambda>)
    10000    0.013    0.000    0.168    0.000 linter.py:401(lint)
```