### PR TITLE
perf: `@cached_property` for avoiding redundant recomputations

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -1,8 +1,11 @@
 import re
 import uuid
 from collections import namedtuple
+from dataclasses import dataclass
 from functools import cached_property
 from itertools import zip_longest
+
+from polib import POEntry
 
 from dennis.tools import (
     VariableTokenizer,
@@ -26,25 +29,28 @@ class HTMLParseError(Exception):
     pass
 
 
+@dataclass(frozen=True)
 class LintMessage:
-    def __init__(self, kind, line, col, code, msg, poentry):
-        self.kind = kind
-        self.line = line
-        self.col = col
-        self.code = code
-        self.msg = msg
-        self.poentry = poentry
+    kind: str
+    line: int
+    col: int
+    code: str
+    msg: str
+    poentry: POEntry
 
     def __repr__(self):
-        return "<LintedMessage {} {}:{} {} {}>".format(
+        return "<LintMessage {} {}:{} {} {}>".format(
             self.kind, self.line, self.col, self.code, self.msg
         )
 
 
+@dataclass(frozen=True)
 class LintedEntry:
-    def __init__(self, poentry):
-        self.poentry = poentry
-        self.msgid = poentry.msgid
+    poentry: POEntry
+
+    @property
+    def msgid(self):
+        return self.poentry.msgid
 
     @property
     def str(self):
@@ -83,7 +89,7 @@ class LintedEntry:
                 )
 
         # List of TranslatedStrings
-        return strs
+        return tuple(strs)
 
 
 class LintRule:
@@ -113,7 +119,7 @@ class MalformedNoTypeLintRule(LintRule):
 
         # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains("python-format"):
-            return msgs
+            return tuple(msgs)
 
         malformed_re = re.compile(
             r"(?:"
@@ -143,7 +149,7 @@ class MalformedNoTypeLintRule(LintRule):
                 )
             )
 
-        return msgs
+        return tuple(msgs)
 
 
 class MalformedMissingRightBraceLintRule(LintRule):
@@ -156,7 +162,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
 
         # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains("python-brace-format"):
-            return []
+            return ()
 
         malformed_re = re.compile(r"(?:\{[^\}]+(?:\{|$))")
         double_open = str(uuid.uuid4())
@@ -189,7 +195,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
                 )
             )
 
-        return msgs
+        return tuple(msgs)
 
 
 class MalformedMissingLeftBraceLintRule(LintRule):
@@ -202,7 +208,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
 
         # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains("python-brace-format"):
-            return []
+            return ()
 
         malformed_re = re.compile(r"(?:(?:^|\})[^\{]*\})")
         double_open = str(uuid.uuid4())
@@ -234,7 +240,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
                     linted_entry.poentry,
                 )
             )
-        return msgs
+        return tuple(msgs)
 
 
 class BadFormatLintRule(LintRule):
@@ -247,7 +253,7 @@ class BadFormatLintRule(LintRule):
 
         # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains("python-format"):
-            return []
+            return ()
 
         splitter = re.compile(r"(\%(?:.|$))")
 
@@ -276,7 +282,7 @@ class BadFormatLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-        return msgs
+        return tuple(msgs)
 
 
 class MissingVarsLintRule(LintRule):
@@ -290,7 +296,7 @@ class MissingVarsLintRule(LintRule):
 
         # If there are no variable formats, skip this rule.
         if not vartok.formats:
-            return []
+            return ()
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
@@ -336,7 +342,7 @@ class MissingVarsLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-        return msgs
+        return tuple(msgs)
 
 
 class BlankLintRule(LintRule):
@@ -363,7 +369,7 @@ class BlankLintRule(LintRule):
                     )
                 )
 
-        return msgs
+        return tuple(msgs)
 
 
 class UnchangedLintRule(LintRule):
@@ -390,7 +396,7 @@ class UnchangedLintRule(LintRule):
                     )
                 )
 
-        return msgs
+        return tuple(msgs)
 
 
 class MismatchedHTMLLintRule(LintRule):
@@ -440,7 +446,7 @@ class MismatchedHTMLLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-                return msgs
+                return tuple(msgs)
 
             if len(trstr.msgid_strings) > 1:
                 # If this is a plural, then we check to see if the two
@@ -463,7 +469,7 @@ class MismatchedHTMLLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-                    return msgs
+                    return tuple(msgs)
 
                 zipped_parts = zip_longest(
                     msgid_parts, msgid_plural_parts, fillvalue=None
@@ -471,7 +477,7 @@ class MismatchedHTMLLintRule(LintRule):
 
                 for left, right in zipped_parts:
                     if not left or not right or not equiv(left, right):
-                        return []
+                        return ()
 
             try:
                 msgstr_parts = tokenize(trstr.msgstr_string)
@@ -487,7 +493,7 @@ class MismatchedHTMLLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-                return msgs
+                return tuple(msgs)
 
             for left, right in zip_longest(msgid_parts, msgstr_parts, fillvalue=None):
                 if not left or not right or not equiv(left, right):
@@ -504,7 +510,7 @@ class MismatchedHTMLLintRule(LintRule):
                         )
                     )
                     break
-        return msgs
+        return tuple(msgs)
 
 
 class InvalidVarsLintRule(LintRule):
@@ -515,7 +521,7 @@ class InvalidVarsLintRule(LintRule):
     def lint(self, vartok, linted_entry):
         # If there are no variable formats, skip this rule.
         if not vartok.formats:
-            return []
+            return ()
 
         msgs = []
         for trstr in linted_entry.strs:
@@ -543,7 +549,7 @@ class InvalidVarsLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-        return msgs
+        return tuple(msgs)
 
 
 def get_lint_rules(with_names=False):
@@ -584,7 +590,7 @@ class Linter:
 
             msgs.extend(lint_rule.lint(self.vartok, linted_entry))
 
-        return msgs
+        return tuple(msgs)
 
     def verify_file(self, filename_or_string):
         """Verifies strings in file.
@@ -602,4 +608,4 @@ class Linter:
         for entry in po.translated_entries():
             msgs.extend(self.lint_poentry(entry))
 
-        return msgs
+        return tuple(msgs)

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -1,6 +1,7 @@
 import re
 import uuid
 from collections import namedtuple
+from functools import cached_property
 from itertools import zip_longest
 
 from dennis.tools import (
@@ -57,7 +58,7 @@ class LintedEntry:
 
         return IdString(msgid_fields, msgid_strings)
 
-    @property
+    @cached_property
     def strs(self):
         poentry = self.poentry
         strs = []

--- a/dennis/templatelinter.py
+++ b/dennis/templatelinter.py
@@ -59,7 +59,7 @@ class HardToReadNamesTLR(TemplateLintRule):
                             linted_entry.poentry,
                         )
                     )
-        return msgs
+        return tuple(msgs)
 
 
 class OneCharNamesTLR(TemplateLintRule):
@@ -92,7 +92,7 @@ class OneCharNamesTLR(TemplateLintRule):
                             linted_entry.poentry,
                         )
                     )
-        return msgs
+        return tuple(msgs)
 
 
 class MultipleUnnamedVarsTLR(TemplateLintRule):
@@ -124,7 +124,7 @@ class MultipleUnnamedVarsTLR(TemplateLintRule):
                         linted_entry.poentry,
                     )
                 )
-        return msgs
+        return tuple(msgs)
 
 
 def get_lint_rules(with_names=False):
@@ -165,7 +165,7 @@ class TemplateLinter:
 
             msgs.extend(lint_rule.lint(self.vartok, linted_entry))
 
-        return msgs
+        return tuple(msgs)
 
     def verify_file(self, filename_or_string):
         """Verifies strings in file.
@@ -182,4 +182,4 @@ class TemplateLinter:
         msgs = []
         for entry in po:
             msgs.extend(self.lint_poentry(entry))
-        return msgs
+        return tuple(msgs)

--- a/dennis/translator.py
+++ b/dennis/translator.py
@@ -434,8 +434,10 @@ class PirateTransform(Transform):
     def nwc(self, c):
         return not self.wc(c)
 
+    _WHITESPACE_RE = re.compile(r"^\s*$")
+
     def is_whitespace(self, s):
-        return re.match("^\\s*$", s) is not None
+        return self._WHITESPACE_RE.match(s) is not None
 
     # List of transform rules. The tuples have:
     #

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -797,3 +797,23 @@ class TestOneCharNamesTLR(TLRTestCase):
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 1
         # FIXME: flesh out this test
+
+
+class TestLintedEntry:
+    def test_strs_is_cached(self):
+        linted_entry = build_linted_entry(
+            '#: foo/foo.py:5\nmsgid "OriginalId"\nmsgstr "OriginalStr"\n'
+        )
+
+        # Access first time to cache the value
+        first_strs = linted_entry.strs
+        assert len(first_strs) == 1
+        assert first_strs[0].msgstr_string == "OriginalStr"
+
+        # Modify underlying poentry
+        linted_entry.poentry.msgstr = "ModifiedStr"
+
+        # Access second time. It should be cached.
+        second_strs = linted_entry.strs
+        assert second_strs is first_strs
+        assert second_strs[0].msgstr_string == "OriginalStr"

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -82,13 +82,13 @@ class TestBadFormatLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "FOO"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo %s"\n' 'msgstr "FOO %s"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_bad_format_character(self):
         linted_entry = build_linted_entry(
@@ -115,7 +115,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "%% foo"\n' 'msgstr "%% FOO"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_not_in_msgid(self):
         # If there are no vars in the msgid, then we don't want to throw errors about stuff we see
@@ -124,7 +124,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "foo 50% omg"\n' 'msgstr "FOO 50% OMG"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_ignore_non_formatting_tokens(self):
         # If the formatting token is actually part of another formatting token, then we want to
@@ -135,7 +135,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
             'msgstr "FOO {startdate:%Y-%m-%d %H:%M} BAR"\n'
         )
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
@@ -143,7 +143,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "%s foo"\n' 'msgstr "%a FOO"\n'
         )
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestMalformedNoTypeLintRule(LintRuleTestCase):
@@ -162,7 +162,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_python_var_with_space(self):
         linted_entry = build_linted_entry(
@@ -213,7 +213,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
@@ -226,7 +226,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
@@ -305,7 +305,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
@@ -355,7 +355,7 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestMissingVarsLintRule(LintRuleTestCase):
@@ -489,7 +489,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr "RECENTLY UPDATED THREADS"\n'
         )
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestInvalidVarsLintRule(LintRuleTestCase):
@@ -501,14 +501,14 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_invalid(self):
         linted_entry = build_linted_entry(
@@ -559,7 +559,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_double_percent(self):
         # Double-percent shouldn't be picked up as a variable.
@@ -571,7 +571,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_urlencoded_urls(self):
         # urlencoding uses % and that shouldn't get picked up
@@ -584,7 +584,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_msgid_no_vars(self):
         linted_entry = build_linted_entry(
@@ -594,7 +594,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
@@ -603,7 +603,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
         )
 
         msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == []
+        assert msgs == ()
 
 
 class TestBlankLintRule(LintRuleTestCase):


### PR DESCRIPTION
Thanks for maintaining Dennis!
Resolves #217.

This yields a roughly 10% reduction in lint execution time (benchmarked with 10k entries).
Memoizing the `strs` property reduced its call count from 90k to 10k,
pushing it down roughly 40 spots in the `internal time` profile ranking.

Profile details:
```console
dennis version 1.2.0
         1761782 function calls (1760502 primitive calls) in 0.448 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.036    0.000    0.276    0.000 linter.py:576(lint_poentry)
        1    0.024    0.024    0.120    0.120 polib.py:1328(parse)
    20000    0.022    0.000    0.089    0.000 parser.py:214(goahead)
    60050    0.017    0.000    0.033    0.000 __init__.py:330(_compile)
    ... (omitted) ...
    10000    0.005    0.000    0.009    0.000 linter.py:60(strs) <--- ✅ Calls reduced 90k → 10k, no longer a hotspot
    ... (omitted) ...
```

Related: #218