### PR TITLE
feat: strict mode for lint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,10 @@ Lint all your PO files for errors::
 
     $ dennis-cmd lint --errorsonly locale/
 
+Lint all your PO files and fail if there are any errors or warnings::
+
+    $ dennis-cmd lint --strict locale/
+
 Lint a POT file for problems::
 
     $ dennis-cmd lint locale/templates/LC_MESSAGES/messages.pot

--- a/dennis/cmdline.py
+++ b/dennis/cmdline.py
@@ -140,12 +140,13 @@ def cli():
 )
 @click.option("--reporter", default="", help="Reporter to use for output.")
 @click.option("--errorsonly/--no-errorsonly", default=False, help="Only print errors.")
+@click.option("--strict/--no-strict", default=False, help="Exit with code 1 if there are any warnings.")
 @click.argument("path", nargs=-1)
 @click.pass_context
 @epilog(
     format_formats() + "\n" + format_lint_rules() + "\n" + format_lint_template_rules()
 )
-def lint(ctx, quiet, varformat, rules, excluderules, reporter, errorsonly, path):
+def lint(ctx, quiet, varformat, rules, excluderules, reporter, errorsonly, strict, path):
     """
     Lints .po/.pot files for issues
 
@@ -315,8 +316,11 @@ def lint(ctx, quiet, varformat, rules, excluderules, reporter, errorsonly, path)
             else:
                 click.echo(f"   {warning_count:5}   {error_count:5}  {locale} ({fn})")
 
-    # Return 0 if everything was fine or 1 if there were errors.
-    ctx.exit(code=1 if total_error_count else 0)
+    # Return 0 if everything was fine or 1 if there were errors (or warnings if strict).
+    if strict:
+        ctx.exit(code=1 if (total_error_count or total_warning_count) else 0)
+    else:
+        ctx.exit(code=1 if total_error_count else 0)
 
 
 @cli.command()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,10 @@ Lint all your PO files for errors::
 
     $ dennis-cmd lint --errorsonly locale/
 
+Lint all your PO files and fail if there are any errors or warnings::
+
+    $ dennis-cmd lint --strict locale/
+
 Lint a POT file for problems::
 
     $ dennis-cmd lint locale/templates/LC_MESSAGES/messages.pot

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -204,8 +204,8 @@ class TestLint:
     @pytest.mark.parametrize(
         "opts, expected_exit_code",
         [
-            ([], 0),
-            (["--strict"], 1),
+            ((), 0),
+            (("--strict",), 1),
         ],
     )
     def test_quiet(self, runner, tmpdir, opts, expected_exit_code):
@@ -215,15 +215,15 @@ class TestLint:
         fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ["lint", "--quiet"] + opts + [str(fn)])
+        result = runner.invoke(cli, ("lint", "--quiet") + opts + (str(fn),))
         assert result.exit_code == expected_exit_code
         assert result.output == ""
 
     @pytest.mark.parametrize(
         "strict_flag, expected_exit_code",
         [
-            ([], 0),
-            (["--strict"], 1),
+            ((), 0),
+            (("--strict",), 1),
         ],
     )
     def test_strict_basic(self, runner, tmpdir, strict_flag, expected_exit_code):
@@ -233,16 +233,16 @@ class TestLint:
         fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ["lint"] + strict_flag + [str(fn)])
+        result = runner.invoke(cli, ("lint",) + strict_flag + (str(fn),))
         assert result.exit_code == expected_exit_code
         assert "Warnings:     1" in result.output
 
     @pytest.mark.parametrize(
         "filter_opts",
         [
-            ["--excluderules", "W301"],
-            ["--rules", "E101"],
-            ["--errorsonly"],
+            ("--excluderules", "W301"),
+            ("--rules", "E101"),
+            ("--errorsonly",),
         ],
     )
     def test_strict_ignores_filtered_warnings(self, runner, tmpdir, filter_opts):
@@ -252,7 +252,7 @@ class TestLint:
         fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ["lint", "--strict"] + filter_opts + [str(fn)])
+        result = runner.invoke(cli, ("lint", "--strict") + filter_opts + (str(fn),))
         assert result.exit_code == 0
         assert "Warnings:" not in result.output
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -201,16 +201,60 @@ class TestLint:
         last_line = result.output.splitlines()[-1]
         assert last_line == 'Error: File "%s" does not exist.' % str(fn)
 
-    def test_quiet(self, runner, tmpdir):
+    @pytest.mark.parametrize(
+        "opts, expected_exit_code",
+        [
+            ([], 0),
+            (["--strict"], 1),
+        ],
+    )
+    def test_quiet(self, runner, tmpdir, opts, expected_exit_code):
         po_file = build_po_string(
-            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr "Foo"\n'
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr " "\n'
         )
         fn = tmpdir.join("messages.po")
         fn.write(po_file)
 
-        result = runner.invoke(cli, ("lint", "--quiet", str(fn)))
-        assert result.exit_code == 0
+        result = runner.invoke(cli, ["lint", "--quiet"] + opts + [str(fn)])
+        assert result.exit_code == expected_exit_code
         assert result.output == ""
+
+    @pytest.mark.parametrize(
+        "strict_flag, expected_exit_code",
+        [
+            ([], 0),
+            (["--strict"], 1),
+        ],
+    )
+    def test_strict_basic(self, runner, tmpdir, strict_flag, expected_exit_code):
+        po_file = build_po_string(
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr " "\n'
+        )
+        fn = tmpdir.join("messages.po")
+        fn.write(po_file)
+
+        result = runner.invoke(cli, ["lint"] + strict_flag + [str(fn)])
+        assert result.exit_code == expected_exit_code
+        assert "Warnings:     1" in result.output
+
+    @pytest.mark.parametrize(
+        "filter_opts",
+        [
+            ["--excluderules", "W301"],
+            ["--rules", "E101"],
+            ["--errorsonly"],
+        ],
+    )
+    def test_strict_ignores_filtered_warnings(self, runner, tmpdir, filter_opts):
+        po_file = build_po_string(
+            "#: foo/foo.py:5\n" 'msgid "Foo bar baz"\n' 'msgstr " "\n'
+        )
+        fn = tmpdir.join("messages.po")
+        fn.write(po_file)
+
+        result = runner.invoke(cli, ["lint", "--strict"] + filter_opts + [str(fn)])
+        assert result.exit_code == 0
+        assert "Warnings:" not in result.output
 
     def test_rules(self, runner, tmpdir):
         po_file = build_po_string(


### PR DESCRIPTION
Closes #210.

I've opted for `--strict`, but I'd be happy to adjust it (e.g., to `--warnings-as-errors`)
if you think another term would be more consistent with the project's naming conventions.