### PR TITLE
perf: Fast path for text without HTML tags to reduce tokenization overhead

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -405,20 +405,22 @@ class MismatchedHTMLLintRule(LintRule):
         def equiv(left, right):
             return left == right
 
-        def tokenize(text):
+        def tokenize(text: str) -> tuple[Token, ...]:
             """Tokenizes the text using the HTMLExtractorTransform
 
             :raises HTMLParseError: If it's invalid HTML.
 
             """
-            html = HTMLExtractorTransform()
+            if "<" not in text:
+                return ()
 
+            html = HTMLExtractorTransform()
             tokens = [
                 token
                 for token in html.transform(vartok, [Token(text)])
                 if token.type == "html" and not token.s.startswith("&")
             ]
-            return sorted(tokens, key=lambda token: token.s)
+            return tuple(sorted(tokens, key=lambda token: token.s))
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:

--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -560,8 +560,7 @@ def get_lint_rules(with_names=False):
 
 def convert_rules(rules_spec):
     lint_rules = get_lint_rules(with_names=True)
-    rules = [lint_rules[rule]() for rule in rules_spec if rule in lint_rules]
-    return rules
+    return tuple(lint_rules[rule]() for rule in rules_spec if rule in lint_rules)
 
 
 class Linter:

--- a/dennis/templatelinter.py
+++ b/dennis/templatelinter.py
@@ -141,8 +141,7 @@ def get_lint_rules(with_names=False):
 
 def convert_rules(rules_spec):
     lint_rules = get_lint_rules(with_names=True)
-    rules = [lint_rules[rule]() for rule in rules_spec if rule in lint_rules]
-    return rules
+    return tuple(lint_rules[rule]() for rule in rules_spec if rule in lint_rules)
 
 
 class TemplateLinter:

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -657,6 +657,15 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 
+    def test_fine_when_no_open_tags(self):
+        # No '<' character - fast path
+        linted_entry = build_linted_entry(
+            "#: foo/foo.py:5\n" 'msgid "b>Foo/b>"\n' 'msgstr "b>ARGH/b>"\n'
+        )
+
+        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        assert len(msgs) == 0
+
     def test_fail(self):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<em>ARGH</em>"\n'


### PR DESCRIPTION
## Motivation
- Optimizes tokenization and HTML parsing to improve lint execution speed by roughly 30%.
- Combined with recent improvements in #218 and #219, total lint execution time has been significantly reduced,
  resulting in **over a 2x speedup** compared to version 1.2.0.

## Profiling
Profiling `dennis-cmd lint` via `cProfile` on a dummy PO file with 10k entries identified that
the overhead of the `tokenize` and `parser` processes accounts for roughly 30% of the total execution time:

**Before:**
```console
         1721919 function calls (1720635 primitive calls) in 0.443 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.036    0.000    0.269    0.000 linter.py:571(lint_poentry)
        1    0.024    0.024    0.121    0.121 polib.py:1328(parse)
    20000    0.022    0.000    0.068    0.000 parser.py:214(goahead)  <-- 📍1
    20000    0.018    0.000    0.126    0.000 linter.py:409(tokenize) <-- 📍2
    10000    0.011    0.000    0.138    0.000 linter.py:401(lint)     <-- 📍3
    .. (omitted) ...
    20000    0.007    0.000    0.080    0.000 translator.py:598(transform) <-- 📍4
    .. (omitted) ...
```

The bottleneck stems from the call chain:
`MismatchedHTMLLintRule.lint` (📍3) → `tokenize` (📍2) → `HTMLExtractorTransform.transform` (📍4) → `HTMLParser.goahead` (📍1).
Currently, the `tokenize` process (and the subsequent `HTMLParser` execution) is triggered for every entry,
even those without any HTML tags, leading to significant unnecessary overhead.

## Implementation
Introduced a fast path in the `tokenize` function to immediately return an empty list
if the text does not contain a `<` character, bypassing the expensive tokenization and parsing logic.

## Rationale
This rule specifically filters for HTML tokens that are not entities:
1. `token.type == "html"`
1. `not token.s.startswith("&")` (excludes entity references)

https://github.com/mozilla/dennis/blob/feeaaa910b4fac3c1a90ce935993b26280bae810/dennis/linter.py#L417-L421

Since any valid HTML tag must start with `<`, checking for the presence of `<` is a sufficient condition
to skip parsing without affecting the correctness of the lint rule.

## Performance gains
Post-optimization, `HTMLParser.goahead` and `MismatchedHTMLLintRule.lint.tokenize` are no longer hotspots in the profile:

**After:**
```console
         1201843 function calls (1200561 primitive calls) in 0.299 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.032    0.000    0.129    0.000 linter.py:574(lint_poentry)
        1    0.024    0.024    0.121    0.121 polib.py:1328(parse)
    .. (omitted) ...
    10000    0.009    0.000    0.011    0.000 linter.py:401(lint)
    .. (omitted) ...
```
