### PR TITLE
perf: Static string fast path to reduce `re.Pattern.findall` overhead

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -129,7 +129,7 @@ class MalformedNoTypeLintRule(LintRule):
             return tuple(msgs)
 
         for trstr in linted_entry.strs:
-            if not trstr.msgstr_string:
+            if not trstr.msgstr_string or "%" not in trstr.msgstr_string:
                 continue
 
             malformed = self._MALFORMED_RE.findall(trstr.msgstr_string)
@@ -168,7 +168,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
             return ()
 
         for trstr in linted_entry.strs:
-            if not trstr.msgstr_string:
+            if not trstr.msgstr_string or "{" not in trstr.msgstr_string:
                 continue
 
             malformed = self._MALFORMED_RE.findall(
@@ -214,7 +214,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
             return ()
 
         for trstr in linted_entry.strs:
-            if not trstr.msgstr_string:
+            if not trstr.msgstr_string or "}" not in trstr.msgstr_string:
                 continue
 
             malformed = self._MALFORMED_RE.findall(
@@ -257,7 +257,7 @@ class BadFormatLintRule(LintRule):
             return ()
 
         for trstr in linted_entry.strs:
-            if not trstr.msgstr_string:
+            if not trstr.msgstr_string or "%" not in trstr.msgstr_string:
                 continue
 
             msgid_tokens = list(vartok.extract_tokens(" ".join(trstr.msgid_strings)))

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -149,20 +149,21 @@ class TestBadFormatLintRule(LintRuleTestCase):
 class TestMalformedNoTypeLintRule(LintRuleTestCase):
     lintrule = MalformedNoTypeLintRule()
 
-    def test_fine(self):
+    @pytest.mark.parametrize(
+        "msgid, msgstr",
+        [
+            ("Foo", "Oof"),
+            ("Foo: {foo}", "Oof: {foo}"),
+            ("Foo: %s", "Oof: %s"),
+        ],
+        ids=["no format tokens", "brace format (fast path)", "python format"],
+    )
+    def test_fine(self, msgid, msgstr):
         linted_entry = build_linted_entry(
-            "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
+            f'#: foo/foo.py:5\nmsgid "{msgid}"\nmsgstr "{msgstr}"\n'
         )
-
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
-
-        linted_entry = build_linted_entry(
-            "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
-        )
-
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
 
     def test_python_var_with_space(self):
         linted_entry = build_linted_entry(
@@ -231,6 +232,19 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
 
 class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
     lintrule = MalformedMissingRightBraceLintRule()
+
+    @pytest.mark.parametrize(
+        "msgid, msgstr",
+        [
+            ("Foo {foo}", "Oof {foo}"),
+            ("Foo {foo}", "Oof foo}"),
+        ],
+        ids=["valid brace format", "no '{' in msgstr (fast path)"],
+    )
+    def test_fine(self, msgid, msgstr):
+        linted_entry = build_linted_entry(f'msgid "{msgid}"\nmsgstr "{msgstr}"\n')
+        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        assert len(msgs) == 0
 
     def test_python_var_missing_right_curly_brace(self):
         linted_entry = build_linted_entry(
@@ -310,6 +324,19 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
 
 class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
     lintrule = MalformedMissingLeftBraceLintRule()
+
+    @pytest.mark.parametrize(
+        "msgid, msgstr",
+        [
+            ("Foo {foo}", "Oof {foo}"),
+            ("Foo {foo}", "Oof {foo"),
+        ],
+        ids=["valid brace format", "no '}' in msgstr (fast path)"],
+    )
+    def test_fine(self, msgid, msgstr):
+        linted_entry = build_linted_entry(f'msgid "{msgid}"\nmsgstr "{msgstr}"\n')
+        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        assert len(msgs) == 0
 
     def test_python_var_missing_left_curly_brace(self):
         linted_entry = build_linted_entry(
@@ -649,20 +676,18 @@ class TestUnchangedLintRule(LintRuleTestCase):
 class TestMismatchedHTMLLintRule(LintRuleTestCase):
     lintrule = MismatchedHTMLLintRule()
 
-    def test_fine(self):
+    @pytest.mark.parametrize(
+        "msgid, msgstr",
+        [
+            ("<b>Foo</b>", "<b>ARGH</b>"),
+            ("b>Foo/b>", "b>ARGH/b>"),
+        ],
+        ids=["valid html", "no '<' in msgstr (fast path)"],
+    )
+    def test_fine(self, msgid, msgstr):
         linted_entry = build_linted_entry(
-            "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<b>ARGH</b>"\n'
+            f'#: foo/foo.py:5\nmsgid "{msgid}"\nmsgstr "{msgstr}"\n'
         )
-
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert len(msgs) == 0
-
-    def test_fine_when_no_open_tags(self):
-        # No '<' character - fast path
-        linted_entry = build_linted_entry(
-            "#: foo/foo.py:5\n" 'msgid "b>Foo/b>"\n' 'msgstr "b>ARGH/b>"\n'
-        )
-
         msgs = self.lintrule.lint(self.vartok, linted_entry)
         assert len(msgs) == 0
 


### PR DESCRIPTION
## Motivation
- Following the same pattern as #221, this PR introduces a fast path for placeholder-related lint rules.

## Profiling
Profiling `dennis-cmd lint` via `cProfile` on a dummy PO file with 10k entries identified that
`re.Pattern.findall` overhead in several lint rules accounts for a significant portion of execution time,
even when processing `msgstr`s that do not contain any placeholders.

**Before:**
```console
         1192627 function calls (1191334 primitive calls) in 0.301 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.034    0.000    0.141    0.000 linter.py:580(lint_poentry)
        1    0.024    0.024    0.121    0.121 polib.py:1328(parse)
   160666    0.011    0.000    0.011    0.000 {method 'get' of 'dict' objects}
    10000    0.010    0.000    0.012    0.000 linter.py:407(lint)
    70000    0.010    0.000    0.010    0.000 {method 'findall' of 're.Pattern' objects}  <--- 🔥 Bottleneck
    10001    0.010    0.000    0.029    0.000 polib.py:965(__init__)
    10001    0.009    0.000    0.014    0.000 polib.py:831(__init__)
    40051    0.009    0.000    0.018    0.000 __init__.py:330(_compile)
    40000    0.009    0.000    0.013    0.000 tools.py:132(extract_tokens)
    [... omitted ...]
```

The primary affected rules were:
- `MalformedNoTypeLintRule` (E101)
- `MalformedMissingRightBraceLintRule` (E102)
- `MalformedMissingLeftBraceLintRule` (E103)
- `BadFormatLintRule` (E104)

## Implementation
Introduced a fast path for each rule's `lint` method to immediately return if the `msgstr` does not contain trigger characters for placeholders.
This allows the linter to bypass the expensive `re.Pattern.findall` for the majority of entries that consist only of static strings.

## Performance gains
Post-optimization, `re.Pattern.findall` is no longer a hotspot.
Implementing fast paths for four rules (E101-E104) eliminated 40k redundant `findall` calls (4 rules × 10k entries) in the benchmark, reducing the total call count from 70k to 30k and yielding roughly an 8% reduction in total execution time.

**After:**
```console
         1092627 function calls (1091334 primitive calls) in 0.278 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.033    0.000    0.115    0.000 linter.py:580(lint_poentry)
        1    0.025    0.025    0.123    0.123 polib.py:1328(parse)
   160666    0.011    0.000    0.011    0.000 {method 'get' of 'dict' objects}
    10001    0.010    0.000    0.030    0.000 polib.py:965(__init__)
    10000    0.010    0.000    0.012    0.000 linter.py:407(lint)
    40051    0.009    0.000    0.019    0.000 __init__.py:330(_compile)
    10001    0.009    0.000    0.014    0.000 polib.py:831(__init__)
    10000    0.007    0.000    0.017    0.000 linter.py:293(lint)
    10001    0.007    0.000    0.052    0.000 polib.py:1624(handle_mi)
    30000    0.007    0.000    0.010    0.000 tools.py:132(extract_tokens)
    [... omitted ...]
    30000    0.004    0.000    0.004    0.000 {method 'findall' of 're.Pattern' objects}  <--- ✅ Calls reduced 70k → 30k, no longer a hotspot
    [... omitted ...]
```
