### PR TITLE
perf: Make lint methods generators to avoid intermediate list accumulation

### DIFF
--- a/dennis/linter.py
+++ b/dennis/linter.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Iterator
 from collections import namedtuple
 from dataclasses import dataclass
 from functools import cached_property
@@ -96,7 +97,9 @@ class LintRule:
     name = ""
     desc = ""
 
-    def lint(self, vartok, linted_entry):
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
         """Takes a linted entry and generates LintMessages
 
         :arg vartok: the variable tokenizer for extracting variables
@@ -121,12 +124,13 @@ class MalformedNoTypeLintRule(LintRule):
         r")"
     )
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains("python-format"):
-            return tuple(msgs)
+            return
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string or "%" not in trstr.msgstr_string:
@@ -137,7 +141,7 @@ class MalformedNoTypeLintRule(LintRule):
                 continue
 
             malformed = [item.strip() for item in malformed]
-            msgs.append(
+            yield (
                 LintMessage(
                     ERROR,
                     linted_entry.poentry.linenum,
@@ -147,8 +151,6 @@ class MalformedNoTypeLintRule(LintRule):
                     linted_entry.poentry,
                 )
             )
-
-        return tuple(msgs)
 
 
 class MalformedMissingRightBraceLintRule(LintRule):
@@ -160,12 +162,13 @@ class MalformedMissingRightBraceLintRule(LintRule):
     _DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
     _DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains("python-brace-format"):
-            return ()
+            return
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string or "{" not in trstr.msgstr_string:
@@ -183,7 +186,7 @@ class MalformedMissingRightBraceLintRule(LintRule):
                 item.strip().replace(self._DOUBLE_OPEN, "{{").replace(self._DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
-            msgs.append(
+            yield (
                 LintMessage(
                     ERROR,
                     linted_entry.poentry.linenum,
@@ -193,8 +196,6 @@ class MalformedMissingRightBraceLintRule(LintRule):
                     linted_entry.poentry,
                 )
             )
-
-        return tuple(msgs)
 
 
 class MalformedMissingLeftBraceLintRule(LintRule):
@@ -206,12 +207,13 @@ class MalformedMissingLeftBraceLintRule(LintRule):
     _DOUBLE_OPEN = "__DENNIS_DOUBLE_OPEN_BRACE__"
     _DOUBLE_CLOSE = "__DENNIS_DOUBLE_CLOSE_BRACE__"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         # This only applies if one of the variable tokenizers is python-brace-format.
         if not vartok.contains("python-brace-format"):
-            return ()
+            return
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string or "}" not in trstr.msgstr_string:
@@ -229,7 +231,7 @@ class MalformedMissingLeftBraceLintRule(LintRule):
                 item.strip().replace(self._DOUBLE_OPEN, "{{").replace(self._DOUBLE_CLOSE, "}}")
                 for item in malformed
             ]
-            msgs.append(
+            yield (
                 LintMessage(
                     ERROR,
                     linted_entry.poentry.linenum,
@@ -239,7 +241,6 @@ class MalformedMissingLeftBraceLintRule(LintRule):
                     linted_entry.poentry,
                 )
             )
-        return tuple(msgs)
 
 
 class BadFormatLintRule(LintRule):
@@ -249,12 +250,13 @@ class BadFormatLintRule(LintRule):
 
     _SPLITTER = re.compile(r"(\%(?:.|$))")
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         # This only applies if one of the variable tokenizers is python-format.
         if not vartok.contains("python-format"):
-            return ()
+            return
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string or "%" not in trstr.msgstr_string:
@@ -271,7 +273,7 @@ class BadFormatLintRule(LintRule):
 
             for match in self._SPLITTER.findall(trstr.msgstr_string):
                 if len(match) == 1 or match[1] not in "(diouxefGgcrs%":
-                    msgs.append(
+                    yield (
                         LintMessage(
                             ERROR,
                             linted_entry.poentry.linenum,
@@ -281,7 +283,6 @@ class BadFormatLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-        return tuple(msgs)
 
 
 class MissingVarsLintRule(LintRule):
@@ -290,12 +291,13 @@ class MissingVarsLintRule(LintRule):
     name = "missingvars"
     desc = "Checks for variables in msgid, but missing in msgstr"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         # If there are no variable formats, skip this rule.
         if not vartok.formats:
-            return ()
+            return
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
@@ -319,7 +321,7 @@ class MissingVarsLintRule(LintRule):
                 ):
                     # If we're looking at python-format variables and one of these is a
                     # python-format variable like %s, then this is an error--not a warning.
-                    msgs.append(
+                    yield (
                         LintMessage(
                             ERROR,
                             linted_entry.poentry.linenum,
@@ -331,7 +333,7 @@ class MissingVarsLintRule(LintRule):
                     )
                 else:
                     # If this is not python-format variables, then this is just a warning.
-                    msgs.append(
+                    yield (
                         LintMessage(
                             WARNING,
                             linted_entry.poentry.linenum,
@@ -341,7 +343,6 @@ class MissingVarsLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-        return tuple(msgs)
 
 
 class BlankLintRule(LintRule):
@@ -349,15 +350,16 @@ class BlankLintRule(LintRule):
     name = "blank"
     desc = "Translated string is only whitespace"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
             if trstr.msgstr_string.isspace():
-                msgs.append(
+                yield (
                     LintMessage(
                         WARNING,
                         linted_entry.poentry.linenum,
@@ -368,23 +370,22 @@ class BlankLintRule(LintRule):
                     )
                 )
 
-        return tuple(msgs)
-
 
 class UnchangedLintRule(LintRule):
     num = "W302"
     name = "unchanged"
     desc = "Makes sure string is actually translated"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
 
             if trstr.msgstr_string in trstr.msgid_strings:
-                msgs.append(
+                yield (
                     LintMessage(
                         WARNING,
                         linted_entry.poentry.linenum,
@@ -395,8 +396,6 @@ class UnchangedLintRule(LintRule):
                     )
                 )
 
-        return tuple(msgs)
-
 
 class MismatchedHTMLLintRule(LintRule):
     num = "W303"
@@ -404,8 +403,9 @@ class MismatchedHTMLLintRule(LintRule):
     name = "html"
     desc = "Checks for matching html between source and translated strings"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         from dennis.translator import HTMLExtractorTransform, Token
 
@@ -437,7 +437,7 @@ class MismatchedHTMLLintRule(LintRule):
                 msgid_parts = tokenize(trstr.msgid_strings[0])
             except HTMLParseError as exc:
                 errmsg = "invalid html: msgid has invalid html {}".format(exc)
-                msgs.append(
+                yield (
                     LintMessage(
                         WARNING,
                         linted_entry.poentry.linenum,
@@ -447,7 +447,7 @@ class MismatchedHTMLLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-                return tuple(msgs)
+                return
 
             if len(trstr.msgid_strings) > 1:
                 # If this is a plural, then we check to see if the two
@@ -460,7 +460,7 @@ class MismatchedHTMLLintRule(LintRule):
                         exc
                     )
 
-                    msgs.append(
+                    yield (
                         LintMessage(
                             WARNING,
                             linted_entry.poentry.linenum,
@@ -470,7 +470,7 @@ class MismatchedHTMLLintRule(LintRule):
                             linted_entry.poentry,
                         )
                     )
-                    return tuple(msgs)
+                    return
 
                 zipped_parts = zip_longest(
                     msgid_parts, msgid_plural_parts, fillvalue=None
@@ -478,13 +478,13 @@ class MismatchedHTMLLintRule(LintRule):
 
                 for left, right in zipped_parts:
                     if not left or not right or not equiv(left, right):
-                        return ()
+                        return
 
             try:
                 msgstr_parts = tokenize(trstr.msgstr_string)
             except HTMLParseError as exc:
                 errmsg = "invalid html: msgstr has invalid html {}".format(exc)
-                msgs.append(
+                yield (
                     LintMessage(
                         WARNING,
                         linted_entry.poentry.linenum,
@@ -494,11 +494,11 @@ class MismatchedHTMLLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-                return tuple(msgs)
+                return
 
             for left, right in zip_longest(msgid_parts, msgstr_parts, fillvalue=None):
                 if not left or not right or not equiv(left, right):
-                    msgs.append(
+                    yield (
                         LintMessage(
                             WARNING,
                             linted_entry.poentry.linenum,
@@ -511,7 +511,6 @@ class MismatchedHTMLLintRule(LintRule):
                         )
                     )
                     break
-        return tuple(msgs)
 
 
 class InvalidVarsLintRule(LintRule):
@@ -519,12 +518,13 @@ class InvalidVarsLintRule(LintRule):
     name = "invalidvars"
     desc = "Checks for variables not in msgid, but in msgstr"
 
-    def lint(self, vartok, linted_entry):
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
         # If there are no variable formats, skip this rule.
         if not vartok.formats:
-            return ()
+            return
 
-        msgs = []
         for trstr in linted_entry.strs:
             if not trstr.msgstr_string:
                 continue
@@ -540,7 +540,7 @@ class InvalidVarsLintRule(LintRule):
             invalid = msgstr_tokens.difference(msgid_tokens)
 
             if invalid:
-                msgs.append(
+                yield (
                     LintMessage(
                         ERROR,
                         linted_entry.poentry.linenum,
@@ -550,7 +550,6 @@ class InvalidVarsLintRule(LintRule):
                         linted_entry.poentry,
                     )
                 )
-        return tuple(msgs)
 
 
 def get_lint_rules(with_names=False):
@@ -581,16 +580,12 @@ class Linter:
 
         skip = parse_dennis_note(poentry.comment)
 
-        msgs = []
-
         # Check the comment to see if what we should ignore.
         for lint_rule in self.rules:
             if skip == "*" or lint_rule.num in skip:
                 continue
 
-            msgs.extend(lint_rule.lint(self.vartok, linted_entry))
-
-        return tuple(msgs)
+            yield from lint_rule.lint(self.vartok, linted_entry)
 
     def verify_file(self, filename_or_string):
         """Verifies strings in file.

--- a/dennis/templatelinter.py
+++ b/dennis/templatelinter.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from dennis.tools import (
     VariableTokenizer,
     all_subclasses,
@@ -15,7 +16,9 @@ class TemplateLintRule:
     name = ""
     desc = ""
 
-    def lint(self, vartok, linted_entry):
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
         """Takes a linted entry and adds errors and warnings
 
         :arg vartok: the variable tokenizer to use for tokenizing
@@ -33,8 +36,9 @@ class HardToReadNamesTLR(TemplateLintRule):
 
     hard_to_read = ("o", "O", "0", "l", "1")
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
 
         idstr = linted_entry.str
 
@@ -49,7 +53,7 @@ class HardToReadNamesTLR(TemplateLintRule):
 
             for token in msgid_tokens:
                 if token in self.hard_to_read:
-                    msgs.append(
+                    yield (
                         LintMessage(
                             WARNING,
                             linted_entry.poentry.linenum,
@@ -59,7 +63,6 @@ class HardToReadNamesTLR(TemplateLintRule):
                             linted_entry.poentry,
                         )
                     )
-        return tuple(msgs)
 
 
 class OneCharNamesTLR(TemplateLintRule):
@@ -67,8 +70,9 @@ class OneCharNamesTLR(TemplateLintRule):
     name = "onechar"
     desc = "Looks for one character variable names"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
         idstr = linted_entry.str
 
         for s in idstr.msgid_strings:
@@ -82,7 +86,7 @@ class OneCharNamesTLR(TemplateLintRule):
 
             for token in msgid_tokens:
                 if len(token) == 1 and token.isalpha():
-                    msgs.append(
+                    yield (
                         LintMessage(
                             WARNING,
                             linted_entry.poentry.linenum,
@@ -92,7 +96,6 @@ class OneCharNamesTLR(TemplateLintRule):
                             linted_entry.poentry,
                         )
                     )
-        return tuple(msgs)
 
 
 class MultipleUnnamedVarsTLR(TemplateLintRule):
@@ -100,8 +103,9 @@ class MultipleUnnamedVarsTLR(TemplateLintRule):
     name = "unnamed"
     desc = "Looks for multiple unnamed variables"
 
-    def lint(self, vartok, linted_entry):
-        msgs = []
+    def lint(
+        self, vartok: VariableTokenizer, linted_entry: LintedEntry
+    ) -> Iterator[LintMessage]:
         idstr = linted_entry.str
 
         for s in idstr.msgid_strings:
@@ -114,7 +118,7 @@ class MultipleUnnamedVarsTLR(TemplateLintRule):
             ]
 
             if msgid_tokens.count("") > 1:
-                msgs.append(
+                yield (
                     LintMessage(
                         WARNING,
                         linted_entry.poentry.linenum,
@@ -124,7 +128,6 @@ class MultipleUnnamedVarsTLR(TemplateLintRule):
                         linted_entry.poentry,
                     )
                 )
-        return tuple(msgs)
 
 
 def get_lint_rules(with_names=False):
@@ -155,16 +158,12 @@ class TemplateLinter:
 
         skip = parse_dennis_note(poentry.comment)
 
-        msgs = []
-
         # Check the comment to see if what we should ignore.
         for lint_rule in self.rules:
             if skip == "*" or lint_rule.num in skip:
                 continue
 
-            msgs.extend(lint_rule.lint(self.vartok, linted_entry))
-
-        return tuple(msgs)
+            yield from lint_rule.lint(self.vartok, linted_entry)
 
     def verify_file(self, filename_or_string):
         """Verifies strings in file.

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -81,20 +81,20 @@ class TestBadFormatLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "FOO"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo %s"\n' 'msgstr "FOO %s"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_bad_format_character(self):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "%s foo"\n' 'msgstr "%a FOO"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E104"
@@ -104,7 +104,7 @@ class TestBadFormatLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "foo %s"\n' 'msgstr "FOO %"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E104"
@@ -114,8 +114,8 @@ class TestBadFormatLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "%% foo"\n' 'msgstr "%% FOO"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_not_in_msgid(self):
         # If there are no vars in the msgid, then we don't want to throw errors about stuff we see
@@ -123,8 +123,8 @@ class TestBadFormatLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "foo 50% omg"\n' 'msgstr "FOO 50% OMG"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_ignore_non_formatting_tokens(self):
         # If the formatting token is actually part of another formatting token, then we want to
@@ -134,16 +134,16 @@ class TestBadFormatLintRule(LintRuleTestCase):
             'msgid "foo {startdate:%Y-%m-%d %H:%M} bar"\n'
             'msgstr "FOO {startdate:%Y-%m-%d %H:%M} BAR"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "%s foo"\n' 'msgstr "%a FOO"\n'
         )
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestMalformedNoTypeLintRule(LintRuleTestCase):
@@ -162,7 +162,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             f'#: foo/foo.py:5\nmsgid "{msgid}"\nmsgstr "{msgstr}"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_python_var_with_space(self):
@@ -173,7 +173,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr[0] "%(count) zoo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E101"
@@ -187,7 +187,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr[0] "%(count)"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E101"
@@ -199,7 +199,7 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgid "%(count)s"\n'
             'msgstr "%(count)!"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E101"
@@ -213,8 +213,8 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr "%(stars)s de %(user)s el %(date)s (%(locale)s)"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
@@ -226,8 +226,8 @@ class TestMalformedNoTypeLintRule(LintRuleTestCase):
             'msgstr[0] "%(count) zoo"\n'
         )
 
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
@@ -243,7 +243,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
     )
     def test_fine(self, msgid, msgstr):
         linted_entry = build_linted_entry(f'msgid "{msgid}"\nmsgstr "{msgstr}"\n')
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_python_var_missing_right_curly_brace(self):
@@ -253,7 +253,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "{foo) bar is the best thing ever"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E102"
@@ -267,7 +267,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "{foo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E102"
@@ -280,7 +280,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E102"
@@ -292,7 +292,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "Valor para la clave \\"{0]\\" excede el tamano de {1}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E102"
@@ -304,7 +304,7 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "{q} | {product}} foo bar"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E102"
@@ -318,8 +318,8 @@ class TestMalformedMissingRightBraceLintRule(LintRuleTestCase):
             'msgstr "Valor para la clave \\"{0}\\" excede el tamano de {1]"\n'
         )
 
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
@@ -335,7 +335,7 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
     )
     def test_fine(self, msgid, msgstr):
         linted_entry = build_linted_entry(f'msgid "{msgid}"\nmsgstr "{msgstr}"\n')
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_python_var_missing_left_curly_brace(self):
@@ -345,7 +345,7 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
             'msgstr "product}-Hilfeforum"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E103"
@@ -357,7 +357,7 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
             'msgstr "{q} | product}-Hilfeforum"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E103"
@@ -369,7 +369,7 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
             'msgstr "This is {{literal}} brace, {0}, and {{another}}."\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_varformat_empty(self):
@@ -381,8 +381,8 @@ class TestMalformedMissingLeftBraceLintRuleTest(LintRuleTestCase):
             'msgstr "{q} | {product}} foo bar"\n'
         )
 
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestMissingVarsLintRule(LintRuleTestCase):
@@ -393,14 +393,14 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_missing(self):
@@ -408,7 +408,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W202"
@@ -420,7 +420,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W202"
@@ -433,7 +433,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo} {bar}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W202"
@@ -451,7 +451,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr[0] "{n} mooo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_plurals_not_missing(self):
@@ -465,7 +465,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr[0] "1 moo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_double_percent(self):
@@ -477,7 +477,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr "more than 50%% of the traffic"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_urlencoded_urls(self):
@@ -490,7 +490,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_python_format_are_errors_unnamed(self):
@@ -501,7 +501,7 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgid "Recently updated threads about %s"\n'
             'msgstr "RECENTLY UPDATED THREADS"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E202"
@@ -515,8 +515,8 @@ class TestMissingVarsLintRule(LintRuleTestCase):
             'msgid "Recently updated threads about %s"\n'
             'msgstr "RECENTLY UPDATED THREADS"\n'
         )
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestInvalidVarsLintRule(LintRuleTestCase):
@@ -527,22 +527,22 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Oof"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo: {foo}"\n' 'msgstr "Oof: {foo}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_invalid(self):
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo {bar}"\n' 'msgstr "Oof: {foo}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E201"
@@ -554,7 +554,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo} {bar} {baz}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E201"
@@ -567,7 +567,7 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "Oof: {foo} {bar}"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "err"
         assert msgs[0].code == "E201"
@@ -585,8 +585,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr[0] "{n} mooo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_double_percent(self):
         # Double-percent shouldn't be picked up as a variable.
@@ -597,8 +597,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "more than 50%% of the traffic"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_urlencoded_urls(self):
         # urlencoding uses % and that shouldn't get picked up
@@ -610,8 +610,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "http://example.com/foo%20%E5%B4%A9%E6%BA%83 is best"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_msgid_no_vars(self):
         linted_entry = build_linted_entry(
@@ -620,8 +620,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             'msgstr "http://it.wikipedia.org/wiki/Canvas_%28elemento_HTML%29"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
+        assert msgs == []
 
     def test_varformat_empty(self):
         vartok = VariableTokenizer([])
@@ -629,8 +629,8 @@ class TestInvalidVarsLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo {bar}"\n' 'msgstr "Oof: {foo}"\n'
         )
 
-        msgs = self.lintrule.lint(vartok, linted_entry)
-        assert msgs == ()
+        msgs = list(self.lintrule.lint(vartok, linted_entry))
+        assert msgs == []
 
 
 class TestBlankLintRule(LintRuleTestCase):
@@ -641,7 +641,7 @@ class TestBlankLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr ""\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_whitespace(self):
@@ -651,7 +651,7 @@ class TestBlankLintRule(LintRuleTestCase):
                 "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "%s"\n' % data
             )
 
-            msgs = self.lintrule.lint(self.vartok, linted_entry)
+            msgs = list(self.lintrule.lint(self.vartok, linted_entry))
             assert len(msgs) == 1
             assert msgs[0].kind == "warn"
             assert msgs[0].code == "W301"
@@ -666,7 +666,7 @@ class TestUnchangedLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo"\n' 'msgstr "Foo"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W302"
@@ -688,7 +688,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
         linted_entry = build_linted_entry(
             f'#: foo/foo.py:5\nmsgid "{msgid}"\nmsgstr "{msgstr}"\n'
         )
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
     def test_fail(self):
@@ -696,7 +696,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<em>ARGH</em>"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W303"
@@ -707,7 +707,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "<b>Foo"\n' 'msgstr "<b>ARGH</b>"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W303"
@@ -717,7 +717,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "<b>Foo</b>"\n' 'msgstr "<b>ARGH"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W303"
@@ -728,7 +728,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" + 'msgid "<a>Foo</a>"\n' + 'msgstr "<a>ARGH</\u0430>"\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         assert msgs[0].kind == "warn"
         assert msgs[0].code == "W303"
@@ -764,7 +764,7 @@ class TestMismatchedHTMLLintRule(LintRuleTestCase):
             "#: foo/foo.py:5\n" 'msgid "tag: <{tag}>"\n' 'msgstr "TAG: <{tag}>"\n'.format(tag=tag)
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 0
 
 
@@ -781,14 +781,14 @@ class TestHardToReadNamesTLR(TLRTestCase):
                 "#: foo/foo.py:5\n" 'msgid "Foo: %(' + c + ')s"\n' 'msgstr ""\n'
             )
 
-            msgs = self.lintrule.lint(self.vartok, linted_entry)
+            msgs = list(self.lintrule.lint(self.vartok, linted_entry))
             assert len(msgs) == 1
 
             linted_entry = build_linted_entry(
                 "#: foo/foo.py:5\n" 'msgid "Foo: {' + c + '}"\n' 'msgstr ""\n'
             )
 
-            msgs = self.lintrule.lint(self.vartok, linted_entry)
+            msgs = list(self.lintrule.lint(self.vartok, linted_entry))
             assert len(msgs) == 1
         # FIXME: flesh out this test
 
@@ -801,14 +801,14 @@ class TestMultipleUnnamedVarsTLR(TLRTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo: %s %s"\n' 'msgstr ""\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo: {} {}"\n' 'msgstr ""\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         # FIXME: flesh out this test
 
@@ -821,14 +821,14 @@ class TestOneCharNamesTLR(TLRTestCase):
             "#: foo/foo.py:5\n" 'msgid "Foo: %(c)s"\n' 'msgstr ""\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
 
         linted_entry = build_linted_entry(
             "#: foo/foo.py:5\n" 'msgid "Foo: {c}"\n' 'msgstr ""\n'
         )
 
-        msgs = self.lintrule.lint(self.vartok, linted_entry)
+        msgs = list(self.lintrule.lint(self.vartok, linted_entry))
         assert len(msgs) == 1
         # FIXME: flesh out this test
 


### PR DESCRIPTION
## Motivation
- Following the same profiling-driven approach as #221, this PR further improves lint execution speed.

## Profiling
Profiling `dennis-cmd lint` via `cProfile` on a dummy PO file with 10k entries identified that
every lint method builds and returns intermediate lists (`msgs = []` → `.append()` → `return msgs`),
and callers merge them with `msgs.extend()`, resulting in 100k+ `list.extend` calls — a significant source of overhead.

**Before:**
```console
         1062706 function calls (1061409 primitive calls) in 0.275 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.032    0.000    0.104    0.000 linter.py:580(lint_poentry)
        1    0.025    0.025    0.125    0.125 polib.py:1328(parse)
   160666    0.011    0.000    0.011    0.000 {method 'get' of 'dict' objects}
    10001    0.010    0.000    0.030    0.000 polib.py:965(__init__)
    10000    0.010    0.000    0.012    0.000 linter.py:407(lint)
    [... omitted ...]
   100190    0.007    0.000    0.007    0.000 {method 'extend' of 'list' objects}  <--- 🔥 100k calls
    [... omitted ...]
```

## Performance gains
Turning all lint methods into generators avoids intermediate list accumulation across 9 lint methods × 10k entries.
This reduced `list.extend` calls from 100k+ to 10k+, yielding roughly an 8% reduction in total execution time.

**After:**
```console
         973528 function calls (972204 primitive calls) in 0.254 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.026    0.000    0.088    0.000 linter.py:562(lint_poentry)
        1    0.024    0.024    0.119    0.119 polib.py:1328(parse)
   160678    0.011    0.000    0.011    0.000 {method 'get' of 'dict' objects}
    10001    0.010    0.000    0.029    0.000 polib.py:965(__init__)
    10000    0.009    0.000    0.011    0.000 linter.py:393(lint)
    [... omitted ...]
    10197    0.003    0.000    0.091    0.000 {method 'extend' of 'list' objects}  <--- ✅ 100k → 10k, ~90% reduction
    [... omitted ...]
```
